### PR TITLE
Update PArguments.cc

### DIFF
--- a/src/jx/Proxy/Mozilla/PArguments.cc
+++ b/src/jx/Proxy/Mozilla/PArguments.cc
@@ -262,6 +262,8 @@ bool PArguments::GetBoolean(const unsigned index) {
     return args_[index].toBoolean();
   else if (args_[index].isNumber())
     return args_[index].toInt32() != 0;
+  else if (args_[index].isString())
+    return GetUTF8Length(index) > 0;    
   else
     return false;
 }


### PR DESCRIPTION
Just two lines of the code, but took me so long to find it.

It started from investigating one of known_issues:

> native packages: they do not check *.jxcore.config file:
```bash
./jx test/run.js -file test/jxcore/test-jx.config-portTCPS.js -n
```

But this was not limited only to packages. Also diagnosis was wrong, since the bug applied only to `portTCPS` value (not entire *.jxcore.config file).

This bug made an https server listening on portTCP instead of portTCPS, since `secure` was **always** evaluated to false in *tcp_wrap.cc#221*:

```js
  if (args.Length() > 2) secure = args.GetBoolean(2);
```

So the following code was always choosing TCP port over TCPS, even for an https servers:
```js
  int bport = -1;
  if (!secure)
    bport = node::commons::GetTCPBoundary();
  else
    bport = node::commons::GetTCPSBoundary();
```