### PR TITLE
jxcore.utils.console improvements

### DIFF
--- a/lib/jx/_jx_utils.js
+++ b/lib/jx/_jx_utils.js
@@ -290,71 +290,46 @@ var ANSI_CODES = {
 		'bgDefault': ['\u001b[49m', '\u001b[49m']
 };
 
-function setColor(str,color,arr) {
-  if(!color) return str;
-  
-  var color_attrs = color.split("+");
-  var ansi_str = "";
-  var found = null;
+function setColor() {
 
-  for(var i=0, attr; attr = color_attrs[i]; i++) {
-	if(ANSI_CODES[attr]){
-		found = attr;
-		ansi_str += ANSI_CODES[attr][0];
-		break;
+	if (!arguments.length)
+		return;
+
+	if (process.env.NOCOLOR || process.env.NODE_DISABLE_COLORS) {
+		str = _util.format.apply(this, arguments);
+		return str;
 	}
-  }
-  
-  if(found){
-	  if(process.env.NOCOLOR || process.env.NODE_DISABLE_COLORS){
-		  str = _util.format.apply(this, arr);
-		  return str;
-	  }
-	  else
-		  ansi_str += str + ANSI_CODES[found][1];
-  }
-  else{
-	  arr.push(color);
-	  str = _util.format.apply(this, arr);
-	  ansi_str = str;
-  }
-  return ansi_str;
+
+	var str_start = "";
+	var str_end = "";
+
+	var color = arguments[arguments.length - 1];
+	if (color && typeof color === "string") {
+		var color_attrs = color.split("+");
+
+		for (var i = 0, attr; attr = color_attrs[i]; i++) {
+			if (ANSI_CODES[attr]) {
+				str_start += ANSI_CODES[attr][0];
+				str_end = ANSI_CODES[attr][1] + str_end;
+			}
+		}
+	}
+
+	var arr = Array.prototype.slice.call(arguments);
+	if (str_start && str_end)
+		arr.pop();
+
+	return str_start + _util.format.apply(this, arr) + str_end;
 }
 
 exports.console = {};
 exports.console.setColor = setColor;
 
-function logMessage() {
-  if(arguments.length>1){
-	  var arr = [];
-	  for(var o=0, ln=arguments.length-1;o<ln;o++){
-		  arr.push(arguments[o]+"");
-	  }
-	  var jump = false;
-	  if(!arguments[arguments.length-1].split){
-		  arr.push(arguments[arguments.length-1]);
-		  jump = true;
-	  }
-	  var str = _util.format.apply(this, arr);
-	  console.log(setColor(str, jump?null:arguments[arr.length], arr));
-  }
-  else{
-	  console.log(arguments[0]);
-  }
+
+exports.console.log = function() {
+	console.log(setColor.apply(null, arguments));
 };
 
-function writeMessage() {
-  if(arguments.length>1){
-	  var arr = [];
-	  for(var o=0, ln=arguments.length-1;o<ln;o++){
-		  arr.push(arguments[o]+"");
-	  }
-	  var str = _util.format.apply(this, arr);
-	  process.stdout.write(setColor(str, arguments[arr.length], arr));
-  }
-  else{
-	  process.stdout.write(arguments[0]);
-  }
+exports.console.write = function() {
+	process.stdout.write(setColor.apply(null, arguments));
 };
-exports.console.log = logMessage;
-exports.console.write = writeMessage;


### PR DESCRIPTION
I propose few changes to `jxcore.utils.console` methods.

1. There was a bug which raised an exception when the last param was null for `log()`:
```js
jxcore.utils.console.log("string", null);
//_jx_utils.js:335
//	  if(!arguments[arguments.length-1].split){
//	                                   ^
//TypeError: Cannot read property 'split' of null
```

2. Unified implementation of `write()` and `log()`

3. Compatibility with core's `console.log()`. Our methods were calling `toString()` per each object, while `console.log()` is stringifying. This was visible e.g. for {} objects or [] arrays:

```js
// our previous implementation:
jxcore.utils.console.log:
 string [object Object] arr 1,2,3 true
// core's and our new implementation:
console.log:
 string { x: 'test' } arr [ 1, 2, 3 ] true
```

4. Implemented combination of attributes, like "red+bold+bgCyan". Previously only the first attribute was taken.

5. `setColor()` is now fully compatible with `log()` and `write()` as it receives multiple arguments.

***

**This is tested for compilation as well as for many different argument usages.**