### PR TITLE
updates for `spawn()`, `execfile()` and relevant test case

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -586,7 +586,7 @@ exports.exec = function(command /* , options, callback */) {
 };
 
 exports.execFile = function(file /* args, options, callback */) {
-  var args, optionArg, callback;
+  var args = [], optionArg, callback;
   var options = {
     encoding: 'utf8',
     timeout: 0,
@@ -596,18 +596,23 @@ exports.execFile = function(file /* args, options, callback */) {
     env: null
   };
 
-  // Parse the parameters.
-
-  if (typeof arguments[arguments.length - 1] === 'function') {
-    callback = arguments[arguments.length - 1];
+  // Parse the optional positional parameters.
+  var pos = 1;
+  if (pos < arguments.length && Array.isArray(arguments[pos])) {
+    args = arguments[pos++];
+  } else if (pos < arguments.length && arguments[pos] == null) {
+    pos++;
   }
-
-  if (Array.isArray(arguments[1])) {
-    args = arguments[1];
-    options = util._extend(options, arguments[2]);
-  } else {
-    args = [];
-    options = util._extend(options, arguments[1]);
+  if (pos < arguments.length && typeof arguments[pos] === 'object') {
+    options = util._extend(options, arguments[pos++]);
+  } else if (pos < arguments.length && arguments[pos] == null) {
+    pos++;
+  }
+  if (pos < arguments.length && typeof arguments[pos] === 'function') {
+    callback = arguments[pos++];
+  }
+  if (pos === 1 && arguments.length > 1) {
+    throw new TypeError('Incorrect value of args option');
   }
 
   var child = spawn(file, args, {
@@ -705,9 +710,7 @@ var spawn = exports.spawn = function(file /* , args, options */) {
   if (Array.isArray(arguments[1])) {
     args = arguments[1].slice(0);
     options = arguments[2];
-  } else if (arguments[1] && !Array.isArray(arguments[1])) {
-    args = [];
-    options = arguments[2];
+  } else if (arguments[1] && typeof arguments[1] !== 'object') {
     throw new TypeError('Incorrect value of args option');
   } else {
     args = [];

--- a/test/simple/test-child-process-spawn-typeerror.js
+++ b/test/simple/test-child-process-spawn-typeerror.js
@@ -1,0 +1,85 @@
+// Copyright & License details are available under JXCORE_LICENSE file
+
+
+var assert = require('assert');
+var child_process = require('child_process');
+var spawn = child_process.spawn;
+var fork = child_process.fork;
+var execFile = child_process.execFile;
+var cmd = (process.platform === 'win32') ? 'rundll32' : 'ls';
+var empty = require('../common').fixturesDir + '/empty.js';
+
+// Argument types for combinatorics
+var a=[], o={}, c=(function callback(){}), s='string', u=undefined, n=null;
+
+// function spawn(file=f [,args=a] [, options=o]) has valid combinations:
+//   (f)
+//   (f, a)
+//   (f, a, o)
+//   (f, o)
+assert.doesNotThrow(function() { spawn(cmd); });
+assert.doesNotThrow(function() { spawn(cmd, a); });
+assert.doesNotThrow(function() { spawn(cmd, a, o); });
+assert.doesNotThrow(function() { spawn(cmd, o); });
+
+// Variants of undefined as explicit 'no argument' at a position
+assert.doesNotThrow(function() { spawn(cmd, u, o); });
+assert.doesNotThrow(function() { spawn(cmd, a, u); });
+assert.doesNotThrow(function() { spawn(cmd, n, o); });
+assert.doesNotThrow(function() { spawn(cmd, a, n); });
+
+assert.throws(function() { spawn(cmd, s); }, TypeError);
+assert.doesNotThrow(function() { spawn(cmd, a, s); }, TypeError);
+
+
+// verify that execFile has same argument parsing behaviour as spawn
+//
+// function execFile(file=f [,args=a] [, options=o] [, callback=c]) has valid
+// combinations:
+//   (f)
+//   (f, a)
+//   (f, a, o)
+//   (f, a, o, c)
+//   (f, a, c)
+//   (f, o)
+//   (f, o, c)
+//   (f, c)
+assert.doesNotThrow(function() { execFile(cmd); });
+assert.doesNotThrow(function() { execFile(cmd, a); });
+assert.doesNotThrow(function() { execFile(cmd, a, o); });
+assert.doesNotThrow(function() { execFile(cmd, a, o, c); });
+assert.doesNotThrow(function() { execFile(cmd, a, c); });
+assert.doesNotThrow(function() { execFile(cmd, o); });
+assert.doesNotThrow(function() { execFile(cmd, o, c); });
+assert.doesNotThrow(function() { execFile(cmd, c); });
+
+// Variants of undefined as explicit 'no argument' at a position
+assert.doesNotThrow(function() { execFile(cmd, u, o, c); });
+assert.doesNotThrow(function() { execFile(cmd, a, u, c); });
+assert.doesNotThrow(function() { execFile(cmd, a, o, u); });
+assert.doesNotThrow(function() { execFile(cmd, n, o, c); });
+assert.doesNotThrow(function() { execFile(cmd, a, n, c); });
+assert.doesNotThrow(function() { execFile(cmd, a, o, n); });
+
+// string is invalid in arg position (this may seem strange, but is
+// consistent across node API, cf. `net.createServer('not options', 'not
+// callback')`
+assert.throws(function() { execFile(cmd, s, o, c); }, TypeError);
+assert.doesNotThrow(function() { execFile(cmd, a, s, c); });
+assert.doesNotThrow(function() { execFile(cmd, a, o, s); });
+
+
+// verify that fork has same argument parsing behaviour as spawn
+//
+// function fork(file=f [,args=a] [, options=o]) has valid combinations:
+//   (f)
+//   (f, a)
+//   (f, a, o)
+//   (f, o)
+assert.doesNotThrow(function() { fork(empty); });
+assert.doesNotThrow(function() { fork(empty, a); });
+assert.doesNotThrow(function() { fork(empty, a, o); });
+assert.doesNotThrow(function() { fork(empty, o); });
+
+assert.throws(function() { fork(empty, s); }, TypeError);
+assert.doesNotThrow(function() { fork(empty, a, s); }, TypeError);


### PR DESCRIPTION
1. The `spawn(cmd, {})` was throwing an exception (the type of `options` argument was compared to Array).
2. Also `execfile()` arguments parsing is redesigned.