### PR TITLE
IOS: Fix crash if jx is run on a jailbroken device

### DIFF
--- a/build_scripts/iosjb_compile.sh
+++ b/build_scripts/iosjb_compile.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+NORMAL_COLOR='\033[0m'
+RED_COLOR='\033[0;31m'
+GREEN_COLOR='\033[0;32m'
+GRAY_COLOR='\033[0;37m'
+
+ARM7=out_ios/arm
+ARM7s=out_ios/armv7s
+ARM64=out_ios/arm64
+FATBIN=out_ios/ios
+
+LOG() {
+    COLOR="$1"
+    TEXT="$2"
+    echo -e "${COLOR}$TEXT ${NORMAL_COLOR}"
+}
+
+
+ERROR_ABORT() {
+	if [[ $? != 0 ]]
+	then
+		LOG $RED_COLOR "compilation aborted\n"
+		exit	
+	fi
+}
+
+
+ERROR_ABORT_MOVE() {
+  if [[ $? != 0 ]]
+  then
+    $($1)
+    LOG $RED_COLOR "compilation aborted for $2 target\n"
+	exit	
+  fi
+}
+
+
+MAKE_INSTALL() {
+  TARGET_DIR="out_$1_ios"
+  PREFIX_DIR="out_ios/$1"
+  mv $TARGET_DIR out
+  ./configure --prefix=$PREFIX_DIR --dest-os=ios --dest-cpu=$1 --engine-mozilla
+  ERROR_ABORT_MOVE "mv out $TARGET_DIR" $1
+  rm -rf $PREFIX_DIR/bin
+  make install -j8
+  ERROR_ABORT_MOVE "mv out $TARGET_DIR" $1
+  mv out $TARGET_DIR
+}
+
+
+MAKE_FAT() {
+	lipo -create "$ARM64/bin/$1" "$ARM7/bin/$1" "$ARM7s/bin/$1" -output "$FATBIN/bin/$1"
+	ERROR_ABORT
+}
+
+
+mkdir out_armv7s_ios
+mkdir out_arm_ios
+mkdir out_arm64_ios
+mkdir out_ios
+
+rm -rf out
+
+LOG $GREEN_COLOR "Compiling IOS ARMv7\n"
+MAKE_INSTALL arm
+
+LOG $GREEN_COLOR "Compiling IOS ARMv7s\n"
+MAKE_INSTALL armv7s
+
+LOG $GREEN_COLOR "Compiling IOS ARM64\n"
+MAKE_INSTALL arm64
+ 
+
+LOG $GREEN_COLOR "Preparing FAT binaries\n"
+rm -rf $FATBIN
+mkdir -p $FATBIN/bin
+mv $ARM7/include $FATBIN/
+
+cp deps/mozjs/src/js.msg $FATBIN/include/node/
+
+MAKE_FAT "jx"
+
+cp src/public/*.h $FATBIN/bin
+
+rm -rf $ARM7s
+rm -rf $ARM7
+rm -rf $ARM64
+
+LOG $GREEN_COLOR "JXcore iOS binaries are ready under $FATBIN"

--- a/src/node.cc
+++ b/src/node.cc
@@ -2048,6 +2048,7 @@ void SetupProcessObject(const int threadId) {
   // this location via argv[0]
   char* docs_home = NULL;
   char* docs_folder = active_engine->argv_[0];
+
   size_t docs_size = strlen(docs_folder);
   for (int i = docs_size - 1; i >= 0; i--) {
     if (docs_folder[i] == '/') {
@@ -2059,10 +2060,10 @@ void SetupProcessObject(const int threadId) {
     }
   }
 
-  assert(docs_home != NULL);
-
-  JS_NAME_SET(process, JS_STRING_ID("userPath"),
-              STD_TO_STRING_WITH_LENGTH(docs_home, docs_size));
+  if (docs_home != NULL) {
+    JS_NAME_SET(process, JS_STRING_ID("userPath"),
+                STD_TO_STRING_WITH_LENGTH(docs_home, docs_size));
+  }
   free(docs_home);
 #endif
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -2063,7 +2063,11 @@ void SetupProcessObject(const int threadId) {
   if (docs_home != NULL) {
     JS_NAME_SET(process, JS_STRING_ID("userPath"),
                 STD_TO_STRING_WITH_LENGTH(docs_home, docs_size));
+  } else {
+    JS_NAME_SET(process, JS_STRING_ID("userPath"),
+                STD_TO_STRING_WITH_LENGTH(docs_folder, docs_size));
   }
+
   free(docs_home);
 #endif
 


### PR DESCRIPTION
Hello.

I've packaged jx for jailbroken ios devices.

If the "jx" binary would be run in the shell, through "jx", and not a path, it would crash.
This small patch fixes that. It's probably not the best way, but it works for now.

Greetings,
vifino