### PR TITLE
Optimize ENGINE_LOG_THIS and JX_Logger. Reformat the debug native calls ...

### DIFF
--- a/src/wrappers/stream_wrap.cc
+++ b/src/wrappers/stream_wrap.cc
@@ -495,7 +495,7 @@ void StreamWrap::AfterWrite(uv_write_t* req, int status) {
 }
 
 JS_METHOD_NO_COM(StreamWrap, Shutdown) {
-  ENGINE_LOG_THIS("StreamWrap", "Shutdown");
+  //ENGINE_LOG_THIS("StreamWrap", "Shutdown"); //already logged in JS_METHOD_NO_COM
   ENGINE_UNWRAP(StreamWrap);
 
   ShutdownWrap* req_wrap = new ShutdownWrap(wrap->com);


### PR DESCRIPTION
...log to include Time/Call and the source file name and line number. Change the criteria for debug native call log rows to be based on both time and number of calls (configurable with defines). Reduce number of string operations and map lookups in JX_Logger::Log. Fix a memory leak of LogDetails instances in JX_Logger::Print.