### PR TITLE
New methods for sending JSON strings to tasks to be directly evaluated

### DIFF
--- a/lib/jx/_jx_tasks.js
+++ b/lib/jx/_jx_tasks.js
@@ -314,33 +314,32 @@ var getMethod = function (method) {
 };
 
 exports.addTask = function (method, script, cb, obj) {
+  if (script == undefined) {
+    script = null;
+  }
+
+  exports._addTask(method, JSON.stringify(script), cb, obj);
+};
+
+exports._addTask = function (method, param, cb, obj) {
+  var cbId = trackerId, tId;
+ 
   if (process.subThread) {
     throw new Error(
       "You can not add a task under a subthread.");
   }
 
   exports.begin();
-  if (script == undefined) {
-    script = null;
-  }
+
   if (method._taskId) {
-    addTask(method._taskId, null, script, cb, obj);
-  } else {
+    tId = method._taskId;
+    method = null;
+  }else{  
     method._taskId = taskId;
+    tId = method._taskId;
     taskId++;
-    var mt = getMethod(method);
-
-    addTask(method._taskId, mt, script, cb, obj);
+    method = getMethod(method);
   }
-
-  if (cinter == null) {
-    gcc_alive = true;
-    runCinter();
-  }
-};
-
-var addTask = function (taskId, method, param, cb, obj) {
-  var cbId = trackerId;
 
   if (cb) {
     markers[cbId] = cb;
@@ -349,18 +348,29 @@ var addTask = function (taskId, method, param, cb, obj) {
     cbId = -1;
   }
 
-  // TODO if null!!! should work
-  param = JSON.stringify(param);
-  var err = uw.addTask(taskId, method, param, cbId, false);
+  var err = uw.addTask(tId, method, param, cbId, false);
 
   if (err > 0) {
     throw new Error("Thread creation error. id:" + err);
   }
 
   trackerId++;
+ 
+  if (cinter == null) {
+    gcc_alive = true;
+    runCinter();
+  }
 };
-
 exports.runOnce = function (method, param, doNotRemember, skip_thread_creation) {
+  if(typeof param !== 'undefined' && param !== null)
+    param = JSON.stringify(param);
+  else
+    param = null;
+	
+  exports._runOnce(method, param, doNotRemember, skip_thread_creation);
+}
+
+exports._runOnce = function (method, param, doNotRemember, skip_thread_creation) {
   if (process.subThread) {
     throw new Error(
       "You can not add a task under a subthread.");
@@ -379,11 +389,6 @@ exports.runOnce = function (method, param, doNotRemember, skip_thread_creation) 
 
   var mt = getMethod(method);
   method._taskId = taskId;
-
-  if(typeof param !== 'undefined' && param !== null)
-    param = JSON.stringify(param);
-  else
-    param = null;
 
   if (doNotRemember === undefined) doNotRemember = false;
 
@@ -408,6 +413,15 @@ exports.register = function (method) {
 };
 
 exports.runOnThread = function (threadId, method, param, cb, obj) {
+  if (param == undefined) {
+    param = null;
+  }
+
+  param = JSON.stringify(param);
+  exports._runOnThread(threadId, method, param, cb, obj);
+}
+
+exports._runOnThread = function (threadId, method, param, cb, obj) {
   if (threadId >= cpuCount) {
     throw new Error(
       "Given threadId does not exist. You can change the number of threads from setThreadCount");
@@ -419,12 +433,6 @@ exports.runOnThread = function (threadId, method, param, cb, obj) {
   }
 
   exports.begin();
-
-  if (param == undefined) {
-    param = null;
-  }
-
-  param = JSON.stringify(param);
 
   var cbId = trackerId;
   if (cb) {

--- a/src/node.js
+++ b/src/node.js
@@ -556,6 +556,14 @@
     Function.prototype.runOnce = function (params) {
       jxcore.tasks.runOnce(this, params);
     };
+
+    Function.prototype._runTask = function (params, callback, objects) {
+      jxcore.tasks._addTask(this, params, callback, objects);
+    };
+
+    Function.prototype._runOnce = function (params) {
+      jxcore.tasks._runOnce(this, params);
+    };
   };
 
   startup._lazyConstants = null;


### PR DESCRIPTION
These commits provide the possibility to directly send params to tasks in an already JSON stringify'd format, through new methods exposed by JXcore that follow its previous syntax. 

jxcore.tasks.**_addTask**(method/object, **JSON Stringify'd param**, callback, obj)
jxcore.tasks.**_runOnce**(method, **JSON Stringify'd param**, doNotRemember)
jxcore.tasks.**_runOnThread**(threadId, method, **JSON Stringify'd param**, callback, obj)
method.**_runTask**(**JSON Stringify'd param**, callback, obj)
method.**_runOnce**(**JSON Stringify'd param**, doNotRemember)

This way tasks' params arrive already parsed into objects (because JX already uses JSON as its communication interface) without the need of another JSON.parse() call.

Follow the same rules of traditional tasks methods for all others properties. http://jxcore.com/docs/jxcore-tasks.html

Accurate testing of new features is still necessary.