### PR TITLE
Handle multiple items being expired out of the memory store

### DIFF
--- a/src/jx/commons.h
+++ b/src/jx/commons.h
@@ -33,6 +33,7 @@
 #ifndef __IOS__
 #include "btree_map.h"
 #define MAP_HOST btree::btree_map
+#define HAS_BTREE_MAP
 #else
 #define MAP_HOST std::map
 #endif

--- a/src/wrappers/jxtimers_wrap.cc
+++ b/src/wrappers/jxtimers_wrap.cc
@@ -29,20 +29,22 @@ void JXTimersWrap::checkKeys() {
   _timerStore *timers = XSpace::Timers();
   if (timers != NULL) {
     _timerStore::iterator it = timers->begin();
-    _timerStore::const_iterator endit = timers->end();
     uint64_t total = uv_hrtime();
     long counter = 0;
 
-    for (; it != endit; ) {
+    while (it != timers->end()) {
       const ttlTimer &timer = it->second;
       if (node::commons::process_status_ != JXCORE_INSTANCE_ALIVE) break;
 
       if (timer.start + timer.slice < total) {
         todelete.push(it->first);
-        timers->erase(++it);
-        endit = timers->end();
+#ifdef HAS_BTREE_MAP
+        it = timers->erase(it);
+#else
+        timers->erase(it++);
+#endif
       }else{
-        it++;
+        ++it;
         counter++;
       }
     }

--- a/src/wrappers/jxtimers_wrap.cc
+++ b/src/wrappers/jxtimers_wrap.cc
@@ -28,23 +28,23 @@ void JXTimersWrap::checkKeys() {
   XSpace::LOCKTIMERS();
   _timerStore *timers = XSpace::Timers();
   if (timers != NULL) {
-    _timerStore::const_iterator it = timers->begin();
+    _timerStore::iterator it = timers->begin();
     _timerStore::const_iterator endit = timers->end();
     uint64_t total = uv_hrtime();
     long counter = 0;
 
-    for (; it != endit; it++) {
-      ttlTimer timer = it->second;
+    for (; it != endit; ) {
+      const ttlTimer &timer = it->second;
       if (node::commons::process_status_ != JXCORE_INSTANCE_ALIVE) break;
 
       if (timer.start + timer.slice < total) {
         todelete.push(it->first);
-        timers->erase(it->first);
-        counter = 1;
-        break;
+        timers->erase(++it);
+        endit = timers->end();
+      }else{
+        it++;
+        counter++;
       }
-
-      counter++;
     }
 
     if (counter == 0) {


### PR DESCRIPTION
Handle multiple items being expired from the memory store in the same loop. Using differing iteration methods for btree_map and std::map. When erasing things out of a btree_map all iterators are invalidated, except the one returned by the erase function itself. Therefore this value must be used. std::map c++98 erase doesn't return a value, so it cannot be used for std::map hence two methods are required.

Tested on heavy usage platform for several days without issue.