### PR TITLE
Safe Block function that can handle different closures

### DIFF
--- a/lib/jx/_jx_memStore.js
+++ b/lib/jx/_jx_memStore.js
@@ -224,38 +224,40 @@ _store.shared.safeBlock = function(key, block, onerr) {
   pid = pid.toString();
 
   if (blockQueue[name]) {
-    blockQueue[name]++;
+    blockQueue[name].push([block, onerr]);
   } else {
-    blockQueue[name] = 1;
+    blockQueue[name] = [[block, onerr]];
 
-    if (_myInter[name] != null && _myInter[name] != undefined) {
-      clearInterval(_myInter[name]);
-    }
-
-    _myInter[name] = setInterval(function() {
-
-      if (blockQueue[name] <= 0) {
-        if (_myInter[name] != null) {
-          clearInterval(_myInter[name]);
-          _myInter[name] = null;
-        }
-        blockQueue[name] = 0;
-      } else if ($uw.setSourceIfEqualsToOrNull("+" + name, pid + "", "-5")) {
-        for (var o = 0; o < blockQueue[name]; o++) {
-          var ex = null;
-          try {
-            block();
-          } catch (e) {
-            ex = e;
+    if (_myInter[name] == null && _myInter[name] == undefined) {
+      _myInter[name] = setInterval(function() {
+        if (blockQueue[name].length <= 0) {
+          if (_myInter[name] != null) {
+            clearInterval(_myInter[name]);
+            delete _myInter[name];
           }
+          delete blockQueue[name];
+        } else if ($uw.setSourceIfEqualsToOrNull("+" + name, pid + "", "-5")) {
+          for (var o in blockQueue[name]) {
+            var ex = null;
+            var funcs = blockQueue[name][o];
+            try {
+              if(funcs && funcs[0]) {
+              	funcs[0]();
+							}
+            } catch (e) {
+              ex = e;
+            }
 
-          if (onerr && ex != null) onerr(ex);
+            if (funcs && funcs[1] && ex != null) {
+              funcs[1](ex);
+            }
+          }
+          delete blockQueue[name];
+          $uw.setSource("+" + name, "-5");
+          clearInterval(_myInter[name]);
+          delete _myInter[name];
         }
-        blockQueue[name] = 0;
-        $uw.setSource("+" + name, "-5");
-        clearInterval(_myInter[name]);
-        _myInter[name] = null;
-      }
-    }, 1);
+      }, 1);
+    }
   }
 };

--- a/lib/jx/_jx_memStore.js
+++ b/lib/jx/_jx_memStore.js
@@ -228,10 +228,20 @@ _store.shared.safeBlock = function(key, block, onerr) {
   } else {
     blockQueue[name] = [[block, onerr]];
 
+    var dtBas = Date.now();
+    var tim = exports.store.shared.getBlockTimeout();
+
     var handleQueue = function() {
+      var timeout = false;
+			if (tim>0 && Date.now() - dtBas > tim) {
+				timeout = true;
+        console.error("JXcore.SafeBlock recovered itself after " + tim
+                + "ms of waiting");
+				dtBas = Date.now();
+			}
       if (blockQueue[name].length <= 0) {
         delete blockQueue[name];
-      } else if ($uw.setSourceIfEqualsToOrNull("+" + name, pid + "", "-5")) {
+      } else if (timeout || $uw.setSourceIfEqualsToOrNull("+" + name, pid + "", "-5")) {
         for (var o in blockQueue[name]) {
           var ex = null;
           var funcs = blockQueue[name][o];

--- a/lib/jx/_jx_memStore.js
+++ b/lib/jx/_jx_memStore.js
@@ -233,12 +233,12 @@ _store.shared.safeBlock = function(key, block, onerr) {
 
     var handleQueue = function() {
       var timeout = false;
-			if (tim>0 && Date.now() - dtBas > tim) {
-				timeout = true;
+      if (tim>0 && Date.now() - dtBas > tim) {
+        timeout = true;
         console.error("JXcore.SafeBlock recovered itself after " + tim
                 + "ms of waiting");
-				dtBas = Date.now();
-			}
+        dtBas = Date.now();
+      }
       if (blockQueue[name].length <= 0) {
         delete blockQueue[name];
       } else if (timeout || $uw.setSourceIfEqualsToOrNull("+" + name, pid + "", "-5")) {

--- a/lib/jx/_jx_memStore.js
+++ b/lib/jx/_jx_memStore.js
@@ -206,7 +206,7 @@ _store.shared.safeBlockSync = function(key, block, onerr) {
   if (onerr && ex != null) onerr(ex);
 };
 
-var _myInter = {}, blockQueue = {};
+var blockQueue = {};
 _store.shared.safeBlock = function(key, block, onerr) {
   if (!key && key !== 0 && key !== false) { throw new TypeError(
           "key can not be null for memory store item"); }
@@ -228,36 +228,31 @@ _store.shared.safeBlock = function(key, block, onerr) {
   } else {
     blockQueue[name] = [[block, onerr]];
 
-    if (_myInter[name] == null && _myInter[name] == undefined) {
-      _myInter[name] = setInterval(function() {
-        if (blockQueue[name].length <= 0) {
-          if (_myInter[name] != null) {
-            clearInterval(_myInter[name]);
-            delete _myInter[name];
+    var handleQueue = function() {
+      if (blockQueue[name].length <= 0) {
+        delete blockQueue[name];
+      } else if ($uw.setSourceIfEqualsToOrNull("+" + name, pid + "", "-5")) {
+        for (var o in blockQueue[name]) {
+          var ex = null;
+          var funcs = blockQueue[name][o];
+          try {
+            if(funcs && funcs[0]) {
+            	funcs[0]();
+					}
+          } catch (e) {
+            ex = e;
           }
-          delete blockQueue[name];
-        } else if ($uw.setSourceIfEqualsToOrNull("+" + name, pid + "", "-5")) {
-          for (var o in blockQueue[name]) {
-            var ex = null;
-            var funcs = blockQueue[name][o];
-            try {
-              if(funcs && funcs[0]) {
-              	funcs[0]();
-							}
-            } catch (e) {
-              ex = e;
-            }
 
-            if (funcs && funcs[1] && ex != null) {
-              funcs[1](ex);
-            }
+          if (funcs && funcs[1] && ex != null) {
+            funcs[1](ex);
           }
-          delete blockQueue[name];
-          $uw.setSource("+" + name, "-5");
-          clearInterval(_myInter[name]);
-          delete _myInter[name];
         }
-      }, 1);
-    }
+        delete blockQueue[name];
+        $uw.setSource("+" + name, "-5");
+      }else{
+    		setTimeout(handleQueue,1);
+			}
+    };
+    setTimeout(handleQueue,1);
   }
 };


### PR DESCRIPTION
The old safeBlock requires the same closure for to be used every time. This is OK if you are only incrementing a counter, but say if you wanted to add a random value to a value in the memory store and always get the correct total, I cannot get it to work correctly.

One of the commit logs contains a function that demonstrates the bug.

This is pretty much a complete rewrite, and javascript isn't my forte, so shout if something doesn't look correct. It seems to work ok, although do you think it will break anything?