### PR TITLE
allow require('.')

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -204,14 +204,13 @@ Module._nodeModulePaths = function (from) {
 };
 
 
-var special_lookup_ = ". ./ ..".split(" ");
 Module._resolveLookupPaths = function (request, parent) {
   if (NativeModule.exists(request)) {
     return [request, []];
   }
 
   var start = request.substring(0, 2);
-  if (!special_lookup_[start]) {
+  if (start !== '.' && start !== './' && start !== '..') {
     var paths = modulePaths;
     if (parent) {
       if (!parent.paths) parent.paths = [];

--- a/lib/module.js
+++ b/lib/module.js
@@ -204,13 +204,14 @@ Module._nodeModulePaths = function (from) {
 };
 
 
+var special_lookup_ = ". ./ ..".split(" ");
 Module._resolveLookupPaths = function (request, parent) {
   if (NativeModule.exists(request)) {
     return [request, []];
   }
 
   var start = request.substring(0, 2);
-  if (start !== './' && start !== '..') {
+  if (!special_lookup_[start]) {
     var paths = modulePaths;
     if (parent) {
       if (!parent.paths) parent.paths = [];


### PR DESCRIPTION
Fix for a reported issue io#1178. It also works for JXcore packaging.

issue:
require(".") should load ./index.js