### PR TITLE
monitor restart did not wait for monitor close

### DIFF
--- a/lib/jx/_jx_monitorHelper.js
+++ b/lib/jx/_jx_monitorHelper.js
@@ -11,25 +11,30 @@ var stopIt = function(restart) {
           "Stopping JXcore monitoring service.", "cyan+bold"));
 
   mon.checkMonitorExists(function(err, msg) {
+
+    var _restartOrExit = function(restart, err, msg) {
+      if (err && msg) console.error(err, msg);
+      console.log("");
+
+      if (restart) {
+        startIt();
+      } else {
+        process.exit(err ? 1 : 0);
+      }
+    };
+
     if (!err) {
-      mon.stopMonitor(function() {
-        // exit without error
-        process.exit(0);
+      mon.stopMonitor(function(err2, msg2) {
+        if (!err2)
+          console.log("Monitoring service is closed now.");
+
+        _restartOrExit(restart, err2, msg2);
       });
-      console.log("Monitoring service is closed.");
     } else {
-      console.log("Monitoring service is not online");
+      console.log("Monitoring service is not online.");
+      _restartOrExit(restart);
     }
 
-    if (msg) console.error(msg);
-    console.log("");
-
-    if (restart) {
-      startIt();
-    } else {
-      if (err)
-        process.exit(1);
-    }
   });
 };
 
@@ -62,7 +67,7 @@ var startMon = function() {
         if (!err) {
           console.log("Monitoring service is started.");
         } else {
-          console.log("Monitoring service is not online");
+          console.log("Monitoring service is not online.");
         }
 
         if (msg) console.error(msg);
@@ -80,7 +85,7 @@ var startIt = function() {
 
   mon.checkMonitorExists(function(err, msg) {
     if (!err) {
-      console.log(color.setColor('Monitoring is already active', "red+bold"));
+      console.log(color.setColor('Monitoring is already active.', "red+bold"));
       process.exit(1);
     } else {
       startMon();


### PR DESCRIPTION
This was not always visible - mostly on slower platforms. The error occurred when `restart` was trying to launch the monitor while the previous was not completely closed yet.