### PR TITLE
average 16% faster packages start up

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -865,7 +865,8 @@ var getRelative = function (parent, child) {
   if (!pdir)
     pdir = path.dirname(parent);
 
-  var cname = path.basename(child);
+  var cparts = path.parts(child);
+  var cname = cparts.basename;
 
   var chilen = child.length;
 
@@ -876,7 +877,7 @@ var getRelative = function (parent, child) {
   var cdir = _dirname(child);
 
   if (!cdir)
-    cdir = path.dirname(child);
+    cdir = cparts.dirname;
 
   if (pdir.indexOf('.' + path.sep) == 0) {
     if (pdir.length > 2)
@@ -1126,12 +1127,16 @@ var readX = function (m, f, obj, pa, eo) {
         jxcore.utils.console.log(eo["message"]);
     }
 
+    var startupRelative = getRelative(f, obj.project.startup);
     for (var o in obj.docs) {
       if (!obj.docs.hasOwnProperty(o)) continue;
       var a = Module.nameFix(o);
 
       var doExtract = eo && (!partialExtract || (partialExtract && extract_what && extract_what.test && extract_what.test(a)));
-      var isStartup = getRelative(f,a) === getRelative(f, obj.project.startup);
+      var rel = getRelative(f,a);
+      var parts = path.parts(rel);
+      var isJS = parts.extname == ".js";
+      var isStartup = rel == startupRelative;
 
       var doEmbed = !doExtract;
       if (obj.project.native || partialExtract) {
@@ -1141,23 +1146,15 @@ var readX = function (m, f, obj, pa, eo) {
       }
 
       if (doEmbed) {
-        var a_embed = a;
-        if (a_embed.length > 3) {
-          if (a_embed.substr(a_embed.length - 3) != '.jx') {
-            a_embed += '.jx';
-          }
-        }
-
-        a_embed = getRelative(f, a_embed);
+        var a_embed = rel;
+        if (parts.extname != ".jx")
+          a_embed += '.jx';
       }
 
       var buff = new Buffer(obj.docs[o], 'base64');
-      var str = jxt._ucmp(buff).toString();
-      var strForEmbed = str;
-      var strForExtract = str;
-      var __ext = path.extname(o);
-      if (__ext == '.js') {
-        strForExtract = new Buffer(str).toString('base64');
+      var strUnpacked = jxt._ucmp(buff).toString();
+      var strForEmbed = strUnpacked;
+      if (isJS) {
         if (doEmbed) {
           var keepb = "/*ouvz&tJXPoaQnod*/\n";
           if (a_embed.indexOf("node_modules") < 0)
@@ -1166,10 +1163,10 @@ var readX = function (m, f, obj, pa, eo) {
             + "')); js.bind=function(){}; return js;});\n";
           var keep = "\n/*mouvz&tJXPoaQnodeJX&vz*/";
 
-          str = str.replace(/^\#\!.*/, ''); // remove shebang
+          strForEmbed = strForEmbed.replace(/^\#\!.*/, ''); // remove shebang
 
-          str = keepb + str + keep;
-          strForEmbed = jxt._cmp(str).toString('base64');
+          strForEmbed = keepb + strForEmbed + keep;
+          strForEmbed = jxt._cmp(strForEmbed).toString('base64');
 
           if (!obj.project.fs_reach_sources) {
             $uw.setSource("X@" + a_embed, "1");
@@ -1197,15 +1194,17 @@ var readX = function (m, f, obj, pa, eo) {
         }
 
         if (write)
-          Module.setSourced(a, strForExtract);
+          Module.setSourced(a, isJS ? new Buffer(strUnpacked).toString('base64') : strUnpacked);
       }
 
       if (doEmbed) {
         $uw.setSource("@" + a_embed, strForEmbed);
-        var dn = path.dirname(a_embed);
-        var bn = path.basename(a_embed);
 
-        if (bn.substr(bn.length - 2) == "jx")
+        var dn = parts.dirname;
+        // basename should be already without ".jx" at the end
+        var bn = parts.basename;
+
+        if (bn.substr(bn.length - 3) == ".jx")
           bn = bn.substr(0, bn.length - 3);
 
         if (!NativeModule.Roots[dn]) {
@@ -1227,9 +1226,8 @@ var readX = function (m, f, obj, pa, eo) {
         NativeModule.Roots[dn][bn] = _fstat;
       }
 
-      str = null;
+      strUnpacked = null;
       strForEmbed = null;
-      strForExtract = null;
       buff = null;
     }
 
@@ -1238,29 +1236,28 @@ var readX = function (m, f, obj, pa, eo) {
     var _cwd = path.normalize(process.cwd());
     var addDir = function(o) {
 
-      if (path.normalize(o) === _cwd || o.length < _cwd.length)
+      if (o === _cwd || o.length < _cwd.length)
         return;
 
-      var _dirname = path.dirname(o);
-      var _basename = path.basename(o);
+      var parts = path.parts(o);
 
-      if (NativeModule.Roots[_dirname] && NativeModule.Roots[_dirname][_basename])
+      if (NativeModule.Roots[parts.dirname] && NativeModule.Roots[parts.dirname][parts.basename])
         return;
 
       if (__existsSync(o))
         return;
 
-      if (!NativeModule.Roots[_dirname])
-        NativeModule.Roots[_dirname] = {};
+      if (!NativeModule.Roots[parts.dirname])
+        NativeModule.Roots[parts.dirname] = {};
 
-      NativeModule.Roots[_dirname][_basename] = new fs.JXStats(null, null, _fstat1);
+      NativeModule.Roots[parts.dirname][parts.basename] = new fs.JXStats(null, null, _fstat1);
       // go down until the process.cwd()
-      addDir(_dirname);
+      addDir(parts.dirname);
     };
 
     for (var o in NativeModule.Roots) {
       if (NativeModule.Roots.hasOwnProperty(o))
-        addDir(o);
+        addDir(path.normalize(o));
     }
 
     delete process.extracting;

--- a/lib/path.js
+++ b/lib/path.js
@@ -406,6 +406,52 @@ exports.extname = function(path) {
   return splitPath(path)[3];
 };
 
+// this returns dirname(), basename() an extname() in one call
+// useful for improving performance when called in a big loop
+var parts = function(path, ext) {
+  var result = splitPath(path);
+  var ret = { dirname : null, basename : null, extname : null };
+
+  /* copied dirname() */
+  var root = result[0], dir = result[1];
+
+  if (!root && !dir) {
+    // No dirname whatsoever
+    ret.dirname = ".";
+  } else {
+    if (dir) {
+      // It has a dirname, strip trailing slash
+      dir = dir.substr(0, dir.length - 1);
+    }
+
+    ret.dirname = root + dir;
+  }
+  /* end of dirname() */
+
+  /* copied basename() */
+  var f = result[2];
+  // TODO: make this comparison case-insensitive on windows?
+  if (ext && f.substr(-1 * ext.length) === ext) {
+    f = f.substr(0, f.length - ext.length);
+  }
+  ret.basename = f;
+  /* end of basename() */
+
+
+  /* copied extname() */
+  ret.extname = result[3];
+  /* end of extname() */
+
+
+  return ret;
+};
+
+// exported but hidden
+Object.defineProperty(exports, 'parts', {
+  enumerable: false,
+  value: parts
+});
+
 exports.exists = util.deprecate(function(path, callback) {
   require('fs').exists(path, callback);
 }, 'path.exists is now called `fs.exists`.');


### PR DESCRIPTION
Those are some optimization steps done for `readX()` method - starting up of packages.

One of the concepts is to avoid multiple subsequent calls:

```js
path.basename(file); 
path.dirname(file);
``` 

as it appears to be expensive when running in larger loops. Instead I'm proposing hidden method for *path.js*:
```js
path.parts(file);
``` 
which returns: 
```js
{ dirname : "xx", basename : "yy", extname : "zz" }
``` 

and it's getting it on a single one path parsing. 

I've benchmarked the changes and they reveal 16% of performance gain (this is an average result). Same for V8 an SM.