### PR TITLE
API: add new embedding API for stopping the main loop

### DIFF
--- a/src/public/jx.cc
+++ b/src/public/jx.cc
@@ -252,6 +252,18 @@ int JX_Loop() {
   return engine->Loop();
 }
 
+void JX_QuitLoop() {
+  JXEngine *engine = JXEngine::ActiveInstance();
+  if (engine == NULL) {
+    warn_console(
+        "(JX_Loop) Did you initialize the JXEngine instance for this "
+        "thread?\n");
+    return;
+  }
+
+  uv_stop(JS_GET_UV_LOOP(engine->GetThreadId()));
+}
+
 bool JX_IsV8() {
 #ifdef JS_ENGINE_V8
   return true;

--- a/src/public/jx.h
+++ b/src/public/jx.h
@@ -60,6 +60,10 @@ JX_LoopOnce();
 JXCORE_EXTERN(int)
 JX_Loop();
 
+// quit event loop
+JXCORE_EXTERN(void)
+JX_QuitLoop();
+
 // returns true if the underlying engine is SpiderMonkey
 JXCORE_EXTERN(bool)
 JX_IsSpiderMonkey();


### PR DESCRIPTION
Wrap uv_stop() and the macro in a public JX API, which can be
accessed from the android JNI interface.