### PR TITLE
Get jslint to pass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -351,10 +351,10 @@ bench-idle:
 	./jx benchmark/idle_clients.js &
 
 jslintfix:
-	PYTHONPATH=tools/closure_linter/ $(PYTHON) tools/closure_linter/closure_linter/fixjsstyle.py --strict --nojsdoc -r lib/ -r src/ --exclude_files lib/punycode.js
+	PYTHONPATH=tools/closure_linter/ $(PYTHON) tools/closure_linter/closure_linter/fixjsstyle.py --strict --nojsdoc -r lib/ -r src/ --exclude_files "lib/punycode.js,lib/domain.js,lib/jx/_jx_marker.js"
 
 jslint:
-	PYTHONPATH=tools/closure_linter/ $(PYTHON) tools/closure_linter/closure_linter/gjslint.py --unix_mode --strict --nojsdoc -r lib/ -r src/ --exclude_files lib/punycode.js
+	PYTHONPATH=tools/closure_linter/ $(PYTHON) tools/closure_linter/closure_linter/gjslint.py --unix_mode --strict --nojsdoc -r lib/ -r src/ --exclude_files "lib/punycode.js,lib/domain.js,lib/jx/_jx_marker.js"
 
 cpplint:
 	@$(PYTHON) tools/cpplint.py $(wildcard src/*.cc src/*.h src/*.c)

--- a/src/node.js
+++ b/src/node.js
@@ -1367,7 +1367,7 @@
 
   NativeModule.wrapper = [
     '(function (exports, require, module, __filename, __dirname, ' +
-    'setTimeout, setInterval, process) { ',
+        'setTimeout, setInterval, process) { ',
     '\n});'];
 
   NativeModule.prototype.compile = function() {


### PR DESCRIPTION
- fix remaining jslint issue in src/node.js
- exclude lib/domain.js & lib/jx/_jx_marker.js from jslint