### PR TITLE
Fix remaining jslint errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -351,10 +351,10 @@ bench-idle:
 	./jx benchmark/idle_clients.js &
 
 jslintfix:
-	PYTHONPATH=tools/closure_linter/ $(PYTHON) tools/closure_linter/closure_linter/fixjsstyle.py --strict --nojsdoc -r lib/ -r src/ --exclude_files lib/punycode.js
+	PYTHONPATH=tools/closure_linter/ $(PYTHON) tools/closure_linter/closure_linter/fixjsstyle.py --strict --nojsdoc -r lib/ -r src/ --exclude_files "lib/punycode.js,lib/jx/_jx_marker.js"
 
 jslint:
-	PYTHONPATH=tools/closure_linter/ $(PYTHON) tools/closure_linter/closure_linter/gjslint.py --unix_mode --strict --nojsdoc -r lib/ -r src/ --exclude_files lib/punycode.js
+	PYTHONPATH=tools/closure_linter/ $(PYTHON) tools/closure_linter/closure_linter/gjslint.py --unix_mode --strict --nojsdoc -r lib/ -r src/ --exclude_files "lib/punycode.js,lib/jx/_jx_marker.js"
 
 cpplint:
 	@$(PYTHON) tools/cpplint.py $(wildcard src/*.cc src/*.h src/*.c)

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -133,22 +133,22 @@ Domain.prototype.bind = function(cb, interceptError) {
       var len = arguments.length;
       var args;
       switch (len) {
-      case 0:
-      case 1:
-        // no args that we care about.
-        args = [];
-        break;
-      case 2:
-        // optimization for most common case: cb(er, data)
-        args = [arguments[1]];
-        break;
-      default:
-        // slower for less common case: cb(er, foo, bar, baz, ...)
-        args = new Array(len - 1);
-        for (var i = 1; i < len; i++) {
-          args[i - 1] = arguments[i];
-        }
-        break;
+        case 0:
+        case 1:
+          // no args that we care about.
+          args = [];
+          break;
+        case 2:
+          // optimization for most common case: cb(er, data)
+          args = [arguments[1]];
+          break;
+        default:
+          // slower for less common case: cb(er, foo, bar, baz, ...)
+          args = new Array(len - 1);
+          for (var i = 1; i < len; i++) {
+            args[i - 1] = arguments[i];
+          }
+          break;
       }
       self.enter();
       var ret = cb.apply(this, args);

--- a/src/node.js
+++ b/src/node.js
@@ -1367,7 +1367,7 @@
 
   NativeModule.wrapper = [
     '(function (exports, require, module, __filename, __dirname, ' +
-    'setTimeout, setInterval, process) { ',
+        'setTimeout, setInterval, process) { ',
     '\n});'];
 
   NativeModule.prototype.compile = function() {


### PR DESCRIPTION
- Fix remaining jslint errors in lib/domain.js & src/node.js
- Exclude lib/jx/_jx_marker.js from jslint

`make jslint` should _now_ pass with no errors

In general, I tried to match the code in Node v0.10 when fixing the jslint errors.