### PR TITLE
jxcore version info in file description (Windows)

### DIFF
--- a/src/node_version.h
+++ b/src/node_version.h
@@ -9,6 +9,10 @@
 
 #define NODE_VERSION_IS_RELEASE 1
 
+#define JXCORE_MAJOR_VERSION 3
+#define JXCORE_MINOR_VERSION 0
+#define JXCORE_PATCH_VERSION 6
+
 #ifndef xNODE_TAG
 #define xNODE_TAG ""
 #endif
@@ -29,13 +33,17 @@
       "-pre"
 #endif
 
+#define JXCORE_VERSION_STRING                                   \
+  "0." NODE_STRINGIFY(JXCORE_MAJOR_VERSION) "." NODE_STRINGIFY( \
+      JXCORE_MINOR_VERSION) "." NODE_STRINGIFY(JXCORE_PATCH_VERSION)
+
 #define NODE_VERSION "v" NODE_VERSION_STRING
 
 #ifdef JS_ENGINE_MOZJS
 #define MOZJS_VERSION 34
-#define JXCORE_VERSION "v Beta-0.3.0.6"
+#define JXCORE_VERSION "v Beta-" JXCORE_VERSION_STRING
 #else
-#define JXCORE_VERSION "v 0.3.0.6"
+#define JXCORE_VERSION "v " JXCORE_VERSION_STRING
 #endif
 
 #define NODE_VERSION_AT_LEAST(major, minor, patch)                  \

--- a/src/res/node.rc
+++ b/src/res/node.rc
@@ -29,7 +29,7 @@
 
 // Version resource
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION NODE_MAJOR_VERSION,NODE_MINOR_VERSION,NODE_PATCH_VERSION,0
+FILEVERSION 0,JXCORE_MAJOR_VERSION,JXCORE_MINOR_VERSION,JXCORE_PATCH_VERSION
 PRODUCTVERSION NODE_MAJOR_VERSION,NODE_MINOR_VERSION,NODE_PATCH_VERSION,0
 FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
@@ -53,8 +53,9 @@ BEGIN
 VALUE "CompanyName", "Nubisa, Inc"
 VALUE "ProductName", "JXcore"
 VALUE "FileDescription", "Evented MT'ed I/O for V8 JavaScript"
-VALUE "FileVersion", NODE_VERSION_STRING
-VALUE "ProductVersion", NODE_VERSION_STRING
+// on Windows the below FileVersion has no effect, since FILEVERSION from above has precedence
+VALUE "FileVersion", JXCORE_VERSION_STRING
+VALUE "ProductVersion", JXCORE_VERSION_STRING " (Node " NODE_VERSION_STRING ")"
 VALUE "OriginalFilename", "jx.exe"
 VALUE "InternalName", "jx"
 VALUE "LegalCopyright", "Copyright Nubisa, Inc. and Node contributors."


### PR DESCRIPTION
This commit is in response for https://github.com/jxcore/jxcore/issues/556 (displaying JXcore version number in jx.exe file properties on Windows).

To make it possible, I needed to split version parts into numbers.

There is also node version mentioned in bracket:

![jx_version_info](https://cloud.githubusercontent.com/assets/5946844/9981334/9ab5f9e6-5fba-11e5-8cf5-1603b834d801.png)

