### PR TITLE
`util.debuglog` method added

### DIFF
--- a/doc/api/util.markdown
+++ b/doc/api/util.markdown
@@ -5,6 +5,36 @@
 These functions are in the module `'util'`. Use `require('util')` to access
 them.
 
+## util.debuglog(section)
+
+* `section` {String} The section of the program to be debugged
+* Returns: {Function} The logging function
+
+This is used to create a function which conditionally writes to stderr
+based on the existence of a `NODE_DEBUG` environment variable.  If the
+`section` name appears in that environment variable, then the returned
+function will be similar to `console.error()`.  If not, then the
+returned function is a no-op.
+
+For example:
+
+```javascript
+var debuglog = util.debuglog('foo');
+
+var bar = 123;
+debuglog('hello from foo [%d]', bar);
+```
+
+If this program is run with `NODE_DEBUG=foo` in the environment, then
+it will output something like:
+
+    FOO 3245: hello from foo [123]
+
+where `3245` is the process id.  If it is not run with that
+environment variable set, then it will not print anything.
+
+You may separate multiple `NODE_DEBUG` environment variables with a
+comma.  For example, `NODE_DEBUG=fs,net,tls`.
 
 ## util.format(format, [...])
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -98,6 +98,26 @@ var error = exports.error = function(x) {
   }
 };
 
+var debugs = {};
+var debugEnviron;
+exports.debuglog = function(set) {
+  if (typeof debugEnviron === 'undefined')
+    debugEnviron = process.env.NODE_DEBUG || '';
+  set = set.toUpperCase();
+  if (!debugs[set]) {
+    if (new RegExp('\\b' + set + '\\b', 'i').test(debugEnviron)) {
+      var pid = process.pid;
+      debugs[set] = function() {
+        var msg = exports.format.apply(exports, arguments);
+        console.error('%s %d: %s', set, pid, msg);
+      };
+    } else {
+      debugs[set] = function() {};
+    }
+  }
+  return debugs[set];
+};
+
 /**
  * Echos the value of a value. Trys to print the value out in the best way
  * possible given the different types.


### PR DESCRIPTION
Used for conditional debugging. Depends on `NODE_DEBUG` env variable. [Issue ref](https://github.com/jxcore/jxcore/issues/571)