### PR TITLE
cork and uncork methods added in writable stream

### DIFF
--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -451,6 +451,15 @@ The amount of bytes sent.
 
 `net.Socket` instances are [EventEmitter][] with the following events:
 
+### Event: 'lookup'
+
+Emitted after resolving the hostname but before connecting.
+Not applicable to UNIX sockets.
+
+* `err` {Error | Null} The error object.  See [dns.lookup()][].
+* `address` {String} The IP address.
+* `family` {String | Null} The address type.  See [dns.lookup()][].
+
 ### Event: 'connect'
 
 Emitted when a socket connection is successfully established.

--- a/doc/api/path.markdown
+++ b/doc/api/path.markdown
@@ -79,6 +79,25 @@ Examples:
     '/home/myself/jx/wwwroot/static_files/gif/image.gif'
     '/home/myself/jx/wwwroot/static_files/gif/image.gif'
 
+## path.isAbsolute(path)
+
+Determines whether `path` is an absolute path. An absolute path will always
+resolve to the same location, regardless of the working directory.
+
+Posix examples:
+
+    path.isAbsolute('/foo/bar') // true
+    path.isAbsolute('/baz/..')  // true
+    path.isAbsolute('qux/')     // false
+    path.isAbsolute('.')        // false
+
+Windows examples:
+
+    path.isAbsolute('//server')  // true
+    path.isAbsolute('C:/foo/..') // true
+    path.isAbsolute('bar\\baz')   // false
+    path.isAbsolute('.')         // false
+
 ## path.relative(from, to)
 
 Solve the relative path from `from` to `to`.

--- a/doc/api/repl.markdown
+++ b/doc/api/repl.markdown
@@ -135,6 +135,27 @@ Example of listening for `exit`:
     });
 
 
+### Event: 'reset'
+
+`function (context) {}`
+
+Emitted when the REPL's context is reset. This happens when you type `.clear`.
+If you start the repl with `{ useGlobal: true }` then this event will never
+be emitted.
+
+Example of listening for `reset`:
+
+    // Extend the initial repl context.
+    r = repl.start({ options ... });
+    someExtension.extend(r.context);
+
+    // When a new context is created extend it as well.
+    r.on('reset', function (context) {
+      console.log('repl has a new context');
+      someExtension.extend(context);
+    });
+
+
 ## REPL Features
 
 <!-- type=misc -->

--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -506,6 +506,16 @@ function writeOneMillionTimes(writer, data, encoding, callback) {
 }
 ```
 
+#### writable.cork()
+
+Forces buffering of all writes.
+
+Buffered data will be flushed either at `.uncork()` or at `.end()` call.
+
+#### writable.uncork()
+
+Flush all data, buffered since `.cork()` call.
+
 #### writable.end([chunk], [encoding], [callback])
 
 * `chunk` {String | Buffer} Optional data to write

--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -516,6 +516,14 @@ Buffered data will be flushed either at `.uncork()` or at `.end()` call.
 
 Flush all data, buffered since `.cork()` call.
 
+#### writable.setDefaultEncoding(encoding)
+
+* `encoding` {String} The new default encoding
+* Return: `Boolean`
+
+Sets the default encoding for a writable stream. Returns `true` if the encoding
+is valid and is set. Otherwise returns `false`.
+
 #### writable.end([chunk], [encoding], [callback])
 
 * `chunk` {String | Buffer} Optional data to write

--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -1021,6 +1021,21 @@ the class that defines it, and should not be called directly by user
 programs.  However, you **are** expected to override this method in
 your own extension classes.
 
+### writable.\_writev(chunks, callback)
+
+* `chunks` {Array} The chunks to be written.  Each chunk has following
+  format: `{ chunk: ..., encoding: ... }`.
+* `callback` {Function} Call this function (optionally with an error
+  argument) when you are done processing the supplied chunks.
+
+Note: **This function MUST NOT be called directly.**  It may be
+implemented by child classes, and called by the internal Writable
+class methods only.
+
+This function is completely optional to implement. In most cases it is
+unnecessary.  If implemented, it will be called with all the chunks
+that are buffered in the write queue.
+
 
 ### Class: stream.Duplex
 

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -89,6 +89,10 @@ function WritableState(options, stream) {
 
   this.buffer = new Array();
 
+  // number of pending user-supplied write callbacks
+  // this must be 0 before 'finish' can be emitted
+  this.pendingcb = 0;
+
   // True if the error was already emitted and should not be thrown again
   this.errorEmitted = false;
 }
@@ -161,8 +165,10 @@ Writable.prototype.write = function(chunk, encoding, cb) {
 
   if (state.ended)
     writeAfterEnd(this, state, cb);
-  else if (validChunk(this, state, chunk, cb))
+  else if (validChunk(this, state, chunk, cb)) {
+    state.pendingcb++;
     ret = writeOrBuffer(this, state, chunk, encoding, cb);
+  }
 
   return ret;
 };
@@ -223,27 +229,33 @@ function writeOrBuffer(stream, state, chunk, encoding, cb) {
   if (state.writing || state.corked)
     state.buffer.push(new WriteReq(chunk, encoding, cb));
   else
-    doWrite(stream, state, len, chunk, encoding, cb);
+    doWrite(stream, state, false, len, chunk, encoding, cb);
 
   return ret;
 }
 
-function doWrite(stream, state, len, chunk, encoding, cb) {
+function doWrite(stream, state, writev, len, chunk, encoding, cb) {
   state.writelen = len;
   state.writecb = cb;
   state.writing = true;
   state.sync = true;
-  stream._write(chunk, encoding, state.onwrite);
+  if (writev)
+    stream._writev(chunk, state.onwrite);
+  else
+    stream._write(chunk, encoding, state.onwrite);
   state.sync = false;
 }
 
 function onwriteError(stream, state, sync, er, cb) {
   if (sync)
     process.nextTick(function() {
+      state.pendingcb--;
       cb(er);
     });
-  else
+  else {
+    state.pendingcb--;
     cb(er);
+  }
 
   stream._writableState.errorEmitted = true;
   stream.emit('error', er);
@@ -283,9 +295,11 @@ function onwrite(stream, er) {
 }
 
 function afterWrite(stream, state, finished, cb) {
-  if (!finished) onwriteDrain(stream, state);
+  if (!finished)
+    onwriteDrain(stream, state);
+  state.pendingcb--;
   cb();
-  if (finished) finishMaybe(stream, state);
+  finishMaybe(stream, state);
 }
 
 // Must force callback to be called on nextTick, so that we don't
@@ -302,30 +316,49 @@ function onwriteDrain(stream, state) {
 function clearBuffer(stream, state) {
   state.bufferProcessing = true;
 
-  for (var c = 0, sb = state.buffer.length; c < sb; c++) {
-    var entry = state.buffer[c];
-    var chunk = entry.chunk;
-    var encoding = entry.encoding;
-    var cb = entry.callback;
-    var len = state.objectMode ? 1 : chunk.length;
+  var sbl = state.buffer.length;
+  var cbs = state.buffer.map(function (entry) {
+    return entry.callback;
+  });
 
-    doWrite(stream, state, len, chunk, encoding, cb);
+  if (sbl) {
+    if (stream._writev) {
+      state.pendingcb++;
+      doWrite(stream, state, true, state.length, state.buffer, '', function(err) {
+        for (var c = 0; c < sbl; c++) {
+          state.pendingcb--;
+          cbs[c](err);
+        }
+      });
+      state.buffer.length = 0;
+    } else {
+      for (var c = 0; c < sbl; c++) {
+        var entry = state.buffer[c];
+        var chunk = entry.chunk;
+        var encoding = entry.encoding;
+        var cb = entry.callback;
+        var len = state.objectMode ? 1 : chunk.length;
 
-    // if we didn't call the onwrite immediately, then
-    // it means that we need to wait until it does.
-    // also, that means that the chunk and cb are currently
-    // being processed, so move the buffer counter past them.
-    if (state.writing) {
-      c++;
-      break;
+        doWrite(stream, state, false, len, chunk, encoding, cb);
+
+        // if we didn't call the onwrite immediately, then
+        // it means that we need to wait until it does.
+        // also, that means that the chunk and cb are currently
+        // being processed, so move the buffer counter past them.
+        if (state.writing) {
+          c++;
+          break;
+        }
+      }
+      if (c < state.buffer.length) {
+        state.buffer = state.buffer.slice(c);
+      } else {
+        state.buffer.length = 0;
+      }
     }
   }
 
   state.bufferProcessing = false;
-  if (c < state.buffer.length)
-    state.buffer = state.buffer.slice(c);
-  else
-    state.buffer.length = 0;
 }
 
 Writable.prototype._write = function(chunk, encoding, cb) {
@@ -367,8 +400,10 @@ function needFinish(stream, state) {
 function finishMaybe(stream, state) {
   var need = needFinish(stream, state);
   if (need) {
-    state.finished = true;
-    stream.emit('finish');
+    if (state.pendingcb === 0) {
+      state.finished = true;
+      stream.emit('finish');
+    }
   }
   return need;
 }

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -188,6 +188,15 @@ Writable.prototype.uncork = function() {
   }
 };
 
+Writable.prototype.setDefaultEncoding = function setDefaultEncoding(encoding) {
+  // node::ParseEncoding() requires lower case.
+  if (typeof encoding === 'string')
+    encoding = encoding.toLowerCase();
+  if (!Buffer.isEncoding(encoding))
+    throw new TypeError('Unknown encoding: ' + encoding);
+  this._writableState.defaultEncoding = encoding;
+};
+
 function decodeChunk(state, chunk, encoding) {
   if (!state.objectMode &&
       state.decodeStrings !== false &&

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -62,6 +62,9 @@ function WritableState(options, stream) {
   // a flag to see when we're in the middle of a write.
   this.writing = false;
 
+  // when true all writes will be buffered until .uncork() call
+  this.corked = 0;
+
   // a flag to be able to tell if the onwrite cb is called immediately,
   // or on a later tick. We set this to true at first, becuase any
   // actions that shouldn't happen until "later" should generally also
@@ -164,6 +167,27 @@ Writable.prototype.write = function(chunk, encoding, cb) {
   return ret;
 };
 
+Writable.prototype.cork = function() {
+  var state = this._writableState;
+
+  state.corked++;
+};
+
+Writable.prototype.uncork = function() {
+  var state = this._writableState;
+
+  if (state.corked) {
+    state.corked--;
+
+    if (!state.writing &&
+        !state.corked &&
+        !state.finished &&
+        !state.bufferProcessing &&
+        state.buffer.length)
+      clearBuffer(this, state);
+  }
+};
+
 function decodeChunk(state, chunk, encoding) {
   if (!state.objectMode &&
       state.decodeStrings !== false &&
@@ -187,7 +211,7 @@ function writeOrBuffer(stream, state, chunk, encoding, cb) {
   // we must ensure that previous needDrain will not be reset to false.
   if (!ret) state.needDrain = true;
 
-  if (state.writing)
+  if (state.writing || state.corked)
     state.buffer.push(new WriteReq(chunk, encoding, cb));
   else
     doWrite(stream, state, len, chunk, encoding, cb);
@@ -236,7 +260,7 @@ function onwrite(stream, er) {
     // Check if we're actually ready to finish, but don't emit yet
     var finished = needFinish(stream, state);
 
-    if (!finished && !state.bufferProcessing && state.buffer.length)
+    if (!finished && !state.corked && !state.bufferProcessing && state.buffer.length)
       clearBuffer(stream, state);
 
     if (sync) {
@@ -313,6 +337,12 @@ Writable.prototype.end = function(chunk, encoding, cb) {
 
   if (typeof chunk !== 'undefined' && chunk !== null)
     this.write(chunk, encoding);
+
+  // .end() fully uncorks
+  if (state.corked) {
+    state.corked = 1;
+    this.uncork();
+  }
 
   // ignore unnecessary end() calls.
   if (!state.ending && !state.finished) endWritable(this, state, cb);

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -89,10 +89,6 @@ function WritableState(options, stream) {
 
   this.buffer = new Array();
 
-  // number of pending user-supplied write callbacks
-  // this must be 0 before 'finish' can be emitted
-  this.pendingcb = 0;
-
   // True if the error was already emitted and should not be thrown again
   this.errorEmitted = false;
 }
@@ -166,7 +162,6 @@ Writable.prototype.write = function(chunk, encoding, cb) {
   if (state.ended)
     writeAfterEnd(this, state, cb);
   else if (validChunk(this, state, chunk, cb)) {
-    state.pendingcb++;
     ret = writeOrBuffer(this, state, chunk, encoding, cb);
   }
 
@@ -249,11 +244,9 @@ function doWrite(stream, state, writev, len, chunk, encoding, cb) {
 function onwriteError(stream, state, sync, er, cb) {
   if (sync)
     process.nextTick(function() {
-      state.pendingcb--;
       cb(er);
     });
   else {
-    state.pendingcb--;
     cb(er);
   }
 
@@ -297,7 +290,6 @@ function onwrite(stream, er) {
 function afterWrite(stream, state, finished, cb) {
   if (!finished)
     onwriteDrain(stream, state);
-  state.pendingcb--;
   cb();
   finishMaybe(stream, state);
 }
@@ -323,10 +315,8 @@ function clearBuffer(stream, state) {
 
   if (sbl) {
     if (stream._writev) {
-      state.pendingcb++;
       doWrite(stream, state, true, state.length, state.buffer, '', function(err) {
         for (var c = 0; c < sbl; c++) {
-          state.pendingcb--;
           cbs[c](err);
         }
       });
@@ -400,10 +390,8 @@ function needFinish(stream, state) {
 function finishMaybe(stream, state) {
   var need = needFinish(stream, state);
   if (need) {
-    if (state.pendingcb === 0) {
-      state.finished = true;
-      stream.emit('finish');
-    }
+    state.finished = true;
+    stream.emit('finish');
   }
   return need;
 }

--- a/lib/net.js
+++ b/lib/net.js
@@ -760,6 +760,8 @@ Socket.prototype.connect = function(options, cb) {
     debug('connect: find host ' + host);
 
     require('dns').lookup(host, function(err, ip, addressType) {
+      self.emit('lookup', err, ip, addressType);
+      
       // It's possible we were destroyed while looking this up.
       // XXX it would be great if we could cancel the promise returned by
       // the look up.

--- a/lib/path.js
+++ b/lib/path.js
@@ -259,6 +259,17 @@ if (isWindows) {
     return outputParts.join('\\');
   };
 
+  // path.isAbsolute(path)
+  // determines whether path is an absolute path
+  // windows version
+  exports.isAbsolute = function(path) {
+    var result = splitDeviceRe.exec(path),
+        device = result[1] || '',
+        isUnc = !!device && device[1] !== ':';
+
+    return isUnc || !!result[2];
+  };
+
   exports.sep = '\\';
   exports.delimiter = ';';
 
@@ -375,6 +386,12 @@ if (isWindows) {
     outputParts = outputParts.concat(toParts.slice(samePartsLength));
 
     return outputParts.join('/');
+  };
+
+  // path.isAbsolute(path)
+  // posix version
+  exports.isAbsolute = function (path) {
+    return path.charAt(0) === '/';
   };
 
   exports.sep = '/';

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -330,6 +330,9 @@ REPLServer.prototype.createContext = function() {
 
 REPLServer.prototype.resetContext = function() {
   this.context = this.createContext();
+  
+  // Allow REPL extensions to extend the new context
+  this.emit('reset', this.context);
 };
 
 REPLServer.prototype.displayPrompt = function(preserveCursor) {

--- a/test/simple/test-net-dns-lookup.js
+++ b/test/simple/test-net-dns-lookup.js
@@ -1,0 +1,43 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var net = require('net');
+var ok = false;
+
+var server = net.createServer(function(client) {
+  client.end();
+  server.close();
+});
+
+server.listen(common.PORT, '127.0.0.1', function() {
+  net.connect(common.PORT, '127.0.0.1').on('lookup', function(err, ip, type) {
+    assert.equal(err, null);
+    assert.equal(ip, '127.0.0.1');
+    assert.equal(type, '4');
+    ok = true;
+  });
+});
+
+process.on('exit', function() {
+  assert(ok);
+});

--- a/test/simple/test-net-dns-lookup.js
+++ b/test/simple/test-net-dns-lookup.js
@@ -1,23 +1,4 @@
-// Copyright Joyent, Inc. and other Node contributors.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a
-// copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to permit
-// persons to whom the Software is furnished to do so, subject to the
-// following conditions:
-//
-// The above copyright notice and this permission notice shall be included
-// in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
-// USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright & License details are available under JXCORE_LICENSE file
 
 var common = require('../common');
 var assert = require('assert');

--- a/test/simple/test-path.js
+++ b/test/simple/test-path.js
@@ -294,6 +294,23 @@ if (isWindows) {
   assert.equal(path.normalize('a//b//.'), 'a/b');
 }
 
+// path.isAbsolute tests
+if (isWindows) {
+  assert.equal(path.isAbsolute('//server/file'), true);
+  assert.equal(path.isAbsolute('\\\\server\\file'), true);
+  assert.equal(path.isAbsolute('C:/Users/'), true);
+  assert.equal(path.isAbsolute('C:\\Users\\'), true);
+  assert.equal(path.isAbsolute('C:cwd/another'), false);
+  assert.equal(path.isAbsolute('C:cwd\\another'), false);
+  assert.equal(path.isAbsolute('directory/directory'), false);
+  assert.equal(path.isAbsolute('directory\\directory'), false);
+} else {
+  assert.equal(path.isAbsolute('/home/foo'), true);
+  assert.equal(path.isAbsolute('/home/foo/..'), true);
+  assert.equal(path.isAbsolute('bar/'), false);
+  assert.equal(path.isAbsolute('./baz'), false);
+}
+
 // path.resolve tests
 if (isWindows) {
   // windows

--- a/test/simple/test-repl-reset-event.js
+++ b/test/simple/test-repl-reset-event.js
@@ -1,0 +1,73 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+common.globalCheck = false;
+
+var assert = require('assert');
+var repl = require('repl');
+var Stream = require('stream');
+
+// create a dummy stream that does nothing
+var dummy = new Stream();
+dummy.write = dummy.pause = dummy.resume = function(){};
+dummy.readable = dummy.writable = true;
+
+function testReset(cb) {
+  var r = repl.start({
+    input: dummy,
+    output: dummy,
+    useGlobal: false
+  });
+  r.context.foo = 42;
+  r.on('reset', function(context) {
+    assert(!!context, 'REPL did not emit a context with reset event');
+    assert.equal(context, r.context, 'REPL emitted incorrect context');
+    assert.equal(context.foo, undefined, 'REPL emitted the previous context, and is not using global as context');
+    context.foo = 42;
+    cb();
+  });
+  r.resetContext();
+}
+
+function testResetGlobal(cb) {
+  var r = repl.start({
+    input: dummy,
+    output: dummy,
+    useGlobal: true
+  });
+  r.context.foo = 42;
+  r.on('reset', function(context) {
+    assert.equal(context.foo, 42, '"foo" property is missing from REPL using global as context');
+    cb();
+  });
+  r.resetContext();
+}
+
+var timeout = setTimeout(function() {
+  assert.fail('Timeout, REPL did not emit reset events');
+}, 5000);
+
+testReset(function() {
+  testResetGlobal(function() {
+    clearTimeout(timeout);
+  });
+});

--- a/test/simple/test-repl-reset-event.js
+++ b/test/simple/test-repl-reset-event.js
@@ -1,23 +1,4 @@
-// Copyright Joyent, Inc. and other Node contributors.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a
-// copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to permit
-// persons to whom the Software is furnished to do so, subject to the
-// following conditions:
-//
-// The above copyright notice and this permission notice shall be included
-// in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
-// USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright & License details are available under JXCORE_LICENSE file
 
 var common = require('../common');
 common.globalCheck = false;

--- a/test/simple/test-stream-writable-change-default-encoding.js
+++ b/test/simple/test-stream-writable-change-default-encoding.js
@@ -1,0 +1,72 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var stream = require('stream');
+var util = require('util');
+
+function MyWritable(fn, options) {
+  stream.Writable.call(this, options);
+  this.fn = fn;
+};
+
+util.inherits(MyWritable, stream.Writable);
+
+MyWritable.prototype._write = function (chunk, encoding, callback) {
+  this.fn(Buffer.isBuffer(chunk), typeof chunk, encoding);
+  callback();
+};
+
+(function defaultCondingIsUtf8() {
+  var m = new MyWritable(function(isBuffer, type, enc) {
+    assert.equal(enc, 'utf8');
+  }, { decodeStrings: false });
+  m.write('foo');
+  m.end();
+}());
+
+(function changeDefaultEncodingToAscii() {
+  var m = new MyWritable(function(isBuffer, type, enc) {
+    assert.equal(enc, 'ascii');
+  }, { decodeStrings: false });
+  m.setDefaultEncoding('ascii');
+  m.write('bar');
+  m.end();
+}());
+
+assert.throws(function changeDefaultEncodingToInvalidValue() {
+  var m = new MyWritable(function(isBuffer, type, enc) {
+  }, { decodeStrings: false });
+  m.setDefaultEncoding({});
+  m.write('bar');
+  m.end();
+}, TypeError);
+
+(function checkVairableCaseEncoding() {
+  var m = new MyWritable(function(isBuffer, type, enc) {
+    assert.equal(enc, 'ascii');
+  }, { decodeStrings: false });
+  m.setDefaultEncoding('AsCii');
+  m.write('bar');
+  m.end();
+}());

--- a/test/simple/test-stream-writable-change-default-encoding.js
+++ b/test/simple/test-stream-writable-change-default-encoding.js
@@ -1,23 +1,4 @@
-// Copyright Joyent, Inc. and other Node contributors.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a
-// copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to permit
-// persons to whom the Software is furnished to do so, subject to the
-// following conditions:
-//
-// The above copyright notice and this permission notice shall be included
-// in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
-// USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright & License details are available under JXCORE_LICENSE file
 
 var common = require('../common');
 var assert = require('assert');

--- a/test/simple/test-stream-writev.js
+++ b/test/simple/test-stream-writev.js
@@ -1,0 +1,121 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+
+var stream = require('stream');
+
+var queue = [];
+for (var decode = 0; decode < 2; decode++) {
+  for (var uncork = 0; uncork < 2; uncork++) {
+    for (var multi = 0; multi < 2; multi++) {
+      queue.push([!!decode, !!uncork, !!multi]);
+    }
+  }
+}
+
+run();
+
+function run() {
+  var t = queue.pop();
+  if (t)
+    test(t[0], t[1], t[2], run);
+  else
+    console.log('ok');
+}
+
+function test(decode, uncork, multi, next) {
+  console.log('# decode=%j uncork=%j multi=%j', decode, uncork, multi);
+  var counter = 0;
+  var expectCount = 0;
+  function cnt(msg) {
+    expectCount++;
+    var expect = expectCount;
+    var called = false;
+    return function(er) {
+      if (er)
+        throw er;
+      called = true;
+      counter++;
+      assert.equal(counter, expect);
+    };
+  }
+
+  var w = new stream.Writable({ decodeStrings: decode });
+  w._write = function(chunk, e, cb) {
+    assert(false, 'Should not call _write');
+  };
+
+  var expectChunks = decode ?
+      [{ encoding: 'buffer',
+         chunk: [104, 101, 108, 108, 111, 44, 32] },
+       { encoding: 'buffer', chunk: [119, 111, 114, 108, 100] },
+       { encoding: 'buffer', chunk: [33] },
+       { encoding: 'buffer',
+         chunk: [10, 97, 110, 100, 32, 116, 104, 101, 110, 46, 46, 46] },
+       { encoding: 'buffer',
+         chunk: [250, 206, 190, 167, 222, 173, 190, 239, 222, 202, 251, 173] }] :
+      [{ encoding: 'ascii', chunk: 'hello, ' },
+       { encoding: 'utf8', chunk: 'world' },
+       { encoding: 'buffer', chunk: [33] },
+       { encoding: 'binary', chunk: '\nand then...' },
+       { encoding: 'hex', chunk: 'facebea7deadbeefdecafbad' }];
+
+  var actualChunks;
+  w._writev = function(chunks, cb) {
+    actualChunks = chunks.map(function(chunk) {
+      return {
+        encoding: chunk.encoding,
+        chunk: Buffer.isBuffer(chunk.chunk) ?
+            Array.prototype.slice.call(chunk.chunk) : chunk.chunk
+      };
+    });
+    cb();
+  };
+
+  w.cork();
+  w.write('hello, ', 'ascii', cnt('hello'));
+  w.write('world', 'utf8', cnt('world'));
+
+  if (multi)
+    w.cork();
+
+  w.write(new Buffer('!'), 'buffer', cnt('!'));
+  w.write('\nand then...', 'binary', cnt('and then'));
+
+  if (multi)
+    w.uncork();
+
+  w.write('facebea7deadbeefdecafbad', 'hex', cnt('hex'));
+
+  if (uncork)
+    w.uncork();
+
+  w.end(cnt('end'));
+
+  w.on('finish', function() {
+    // make sure finish comes after all the write cb
+    cnt('finish')();
+    assert.deepEqual(expectChunks, actualChunks);
+    next();
+  });
+}

--- a/test/simple/test-stream-writev.js
+++ b/test/simple/test-stream-writev.js
@@ -1,23 +1,4 @@
-// Copyright Joyent, Inc. and other Node contributors.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a
-// copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to permit
-// persons to whom the Software is furnished to do so, subject to the
-// following conditions:
-//
-// The above copyright notice and this permission notice shall be included
-// in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
-// USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright & License details are available under JXCORE_LICENSE file
 
 var common = require('../common');
 var assert = require('assert');


### PR DESCRIPTION
[Adding methods from node v0.12.7 issue](https://github.com/jxcore/jxcore/issues/571)

Added `Writable.cork` method that forces buffering of all writes. [See docs](http://nodejs.org/dist/v0.12.7/docs/api/stream.html#stream_writable_cork).
Added `Writable.setDefaultEncoding` method. [See docs](http://nodejs.org/dist/v0.12.7/docs/api/stream.html#stream_writable_setdefaultencoding_encoding)
Added `path.isAbsolute` method. [See docs](https://nodejs.org/docs/latest-v0.12.x/api/path.html#path_path_isabsolute_path)
Added `lookup` event when calling `socket.connect` (triggers after `dns.lookup`). [See docs](https://nodejs.org/docs/latest-v0.12.x/api/net.html#net_event_lookup)
Added `reset` event to repl. Triggers when calling `.clear` from repl client. [See docs](https://nodejs.org/docs/latest-v0.12.x/api/repl.html#repl_event_reset)
Added `Writable._writev` method. [See docs](http://nodejs.org/dist/v0.12.7/docs/api/stream.html#stream_writable_writev_chunks_callback)