### PR TITLE
Some fixes for 0.3.1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -389,10 +389,10 @@ bench-idle:
 	./jx benchmark/idle_clients.js &
 
 jslintfix:
-	PYTHONPATH=tools/closure_linter/ $(PYTHON) tools/closure_linter/closure_linter/fixjsstyle.py --strict --nojsdoc -r lib/ -r src/ --exclude_files lib/punycode.js
+	PYTHONPATH=tools/closure_linter/ $(PYTHON) tools/closure_linter/closure_linter/fixjsstyle.py --strict --nojsdoc -r lib/ -r src/ --exclude_files "lib/punycode.js,lib/jx/_jx_marker.js"
 
 jslint:
-	PYTHONPATH=tools/closure_linter/ $(PYTHON) tools/closure_linter/closure_linter/gjslint.py --unix_mode --strict --nojsdoc -r lib/ -r src/ --exclude_files lib/punycode.js
+	PYTHONPATH=tools/closure_linter/ $(PYTHON) tools/closure_linter/closure_linter/gjslint.py --unix_mode --strict --nojsdoc -r lib/ -r src/ --exclude_files "lib/punycode.js,lib/jx/_jx_marker.js"
 
 CPPLINT_EXCLUDE ?=
 CPPLINT_EXCLUDE += src/node_root_certs.h

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -274,8 +274,11 @@ function onwrite(stream, er) {
     // Check if we're actually ready to finish, but don't emit yet
     var finished = needFinish(stream, state);
 
-    if (!finished && !state.corked && !state.bufferProcessing && state.buffer.length)
+    if (!finished &&
+        !state.corked &&
+        !state.bufferProcessing && state.buffer.length) {
       clearBuffer(stream, state);
+    }
 
     if (sync) {
       process.nextTick(function() {
@@ -309,13 +312,14 @@ function clearBuffer(stream, state) {
   state.bufferProcessing = true;
 
   var sbl = state.buffer.length;
-  var cbs = state.buffer.map(function (entry) {
+  var cbs = state.buffer.map(function(entry) {
     return entry.callback;
   });
 
   if (sbl) {
     if (stream._writev) {
-      doWrite(stream, state, true, state.length, state.buffer, '', function(err) {
+      var buf = state.buffer; // make jslint happy
+      doWrite(stream, state, true, state.length, buf, '', function(err) {
         for (var c = 0; c < sbl; c++) {
           cbs[c](err);
         }

--- a/lib/jx/_jx_incoming.js
+++ b/lib/jx/_jx_incoming.js
@@ -56,7 +56,7 @@ var IncomingMessage = function(socket, info, url) {
     this.httpVersionMajor = info.versionMajor;
     this.httpVersionMinor = info.versionMinor;
   }
-  
+
   this.complete = false;
   this.headers = {};
   this.trailers = {};

--- a/lib/jx/_jx_package.js
+++ b/lib/jx/_jx_package.js
@@ -489,10 +489,12 @@ var signFile = function(signOptions, fileName) {
     _cmd = 'signtool sign ' + _cmd.trim() + ' "' + fileName + '"';
     var ret = jxcore.utils.cmdSync(_cmd);
     if (ret.exitCode) {
-      jxcore.utils.console.log('\nUnable to sign the native package:', 'magenta');
+      jxcore.utils.console.log('\nUnable to sign the native package:',
+                               'magenta');
       jxcore.utils.console.log(ret.out, 'red');
     } else {
-      jxcore.utils.console.log('\nThe package was successfully signed.', 'yellow');
+      jxcore.utils.console.log('\nThe package was successfully signed.',
+                               'yellow');
     }
   }
 };

--- a/lib/net.js
+++ b/lib/net.js
@@ -761,7 +761,7 @@ Socket.prototype.connect = function(options, cb) {
 
     require('dns').lookup(host, function(err, ip, addressType) {
       self.emit('lookup', err, ip, addressType);
-      
+
       // It's possible we were destroyed while looking this up.
       // XXX it would be great if we could cancel the promise returned by
       // the look up.

--- a/lib/path.js
+++ b/lib/path.js
@@ -390,7 +390,7 @@ if (isWindows) {
 
   // path.isAbsolute(path)
   // posix version
-  exports.isAbsolute = function (path) {
+  exports.isAbsolute = function(path) {
     return path.charAt(0) === '/';
   };
 

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -330,7 +330,7 @@ REPLServer.prototype.createContext = function() {
 
 REPLServer.prototype.resetContext = function() {
   this.context = this.createContext();
-  
+
   // Allow REPL extensions to extend the new context
   this.emit('reset', this.context);
 };

--- a/src/wrappers/tcp_wrap.cc
+++ b/src/wrappers/tcp_wrap.cc
@@ -15,8 +15,8 @@ JS_LOCAL_OBJECT AddressToJS(JS_STATE_MARKER, const sockaddr* addr);
 
 JS_LOCAL_OBJECT TCPWrap::InstantiateCOM(commons* _com) {
   commons* com = _com != NULL ? _com : commons::getInstance();
-  JS_ENTER_SCOPE_WITH(_com->node_isolate);
-  JS_DEFINE_STATE_MARKER(_com);
+  JS_ENTER_SCOPE_WITH(com->node_isolate);
+  JS_DEFINE_STATE_MARKER(com);
 
   assert(JS_IS_EMPTY(com->tcpConstructor) == false);
 

--- a/test/simple/test-domain.js
+++ b/test/simple/test-domain.js
@@ -88,6 +88,8 @@ d.on('error', function(er) {
       assert.ok(!er.domainBound);
       break;
 
+    case "Cannot read property 'isDirectory' of undefined":
+    // For old JS engine:
     case 'Cannot call method \'isDirectory\' of undefined':
       assert.equal(er.domain, d);
       assert.ok(!er.domainEmitter);

--- a/test/simple/test-process-config.js
+++ b/test/simple/test-process-config.js
@@ -12,18 +12,7 @@ assert(process.hasOwnProperty('config'));
 // ensure that `process.config` is an Object
 assert(Object(process.config) === process.config);
 
-var builds = [ "sm", "v8" ];
-var build = "";
-
-for(var o in builds) {
-  if (process.versions[builds[o]]) {
-    build = builds[o];
-    break;
-  }
-}
-
-var configPath = __filename + '-config.gypi_' + build;
-assert.ok(fs.existsSync(configPath), path.basename(configPath) + " file not found. Please run configure.")
+var configPath = path.resolve(__dirname, '..', '..', 'config.gypi');
 var config = fs.readFileSync(configPath, 'utf8');
 
 // clean up comment at the first line


### PR DESCRIPTION
Fixes so far (#585):

- Copied `test/simple/test-process-config.js` from Node 0.10.x/0.12.x (but kept the existing file header), now passes OK
- ~~Quick fix to `src/jx/jx_instance.cc` to get background jobs to work in default V8 build configuration and pass `test/simple/test-api-tasks.js`~~

UPDATE(s):
- fixed jslint errors