### PR TITLE
Efficiently repair reading of signed files

### DIFF
--- a/lib/jx/_jx_package.js
+++ b/lib/jx/_jx_package.js
@@ -244,7 +244,6 @@ var binaryFileIndexOf = function(file_name, testString, writeDotAt) {
 	if(writeDotAt) {
 		while(totalLoc < sz && checksComplete < totalChecks) {
 			if (loc % writeDotAt == 0) writeDot();
-			if(totalLoc - lastTotalLoc !== chunkSize)
 			if(sz < totalLoc + chunkSize)
 				buffer = new Buffer(chunkSize = sz-totalLoc);
 			fs.readSync(fd, buffer, 0, chunkSize, lastTotalLoc = totalLoc);

--- a/lib/jx/_jx_package.js
+++ b/lib/jx/_jx_package.js
@@ -794,6 +794,34 @@ exports.compile = function(argv, ops) {
         copy = os_info.isWindows ? 'copy /Y' : 'cp',
         copy_ext = os_info.isWindows ? '.exe' : '';
 
+	var replaceStrings = function(file_name) {
+		// replacing strings inside binary
+		// called at one of two different positions in the code
+		var index1 = binaryFileIndexOf(file_name, 'bin@ry.v@rsio' + 'n@', 32768);
+		var index2 = binaryFileIndexOf(file_name, 'jxcore.bi' + 'n(?@@', 32768);
+		if (index1 === -1 || index2 === -1) {
+			cc('\nUnable to compile. Make sure the JX binary is not corrupted', 'red');
+			process.exit(1);
+			return false; }
+		var sz = fss.statSync(file_name).size;
+		var fd = fss.openSync(file_name, 'r+');
+		// first string
+		var buffer = new Buffer(parseInt((5 * (sz - cmped.length - 32)) - 123456789) + '').toString('hex');
+		buffer += ')'; for (var o = buffer.length; o < 42; o++) { buffer += parseInt(Math.random() * 9) + ''; }
+		buffer = new Buffer(new Buffer('bin@ry.v@rsion' +
+			buffer.replace(/[d]/g, '*').replace(/[0]/g, '#').replace(/[1]/g,
+			  '$').replace(/[2]/g, '@').replace(/[3]/g, '!').replace(/[4]/g,
+			  '(').replace(/[5]/g, '{').replace(/[6]/g, '?').replace(/[7]/g,
+			  '<').replace(/[8]/g, ']').replace(/[9]/g, '|')));
+		fss.writeSync(fd, buffer, 0, 56, index1);
+		// second string
+		buffer = new Buffer(nativePackageMarker);
+		fss.writeSync(fd, buffer, 0, 23, index2);
+		fss.closeSync(fd);
+		jxcore.tasks.forceGC();
+		return true;
+		};
+
     if (true) { // make jslint happy
       var file_name = process.cwd() + path.sep + op;
       file_name = nameFix(file_name);
@@ -842,45 +870,15 @@ exports.compile = function(argv, ops) {
         process.exit(1);
       }
 
-      // replacing strings inside binary
-      var index1 = binaryFileIndexOf(file_name, 'bin@ry.v@rsio' + 'n@', 32768);
-      var index2 = binaryFileIndexOf(file_name, 'jxcore.bi' + 'n(?@@', 32768);
-      if (index1 === -1 || index2 === -1) {
-        cc('\nUnable to compile. Make sure the JX binary is not corrupted',
-            'red');
-        process.exit(1);
-        return;
-      }
-
-      var sz = fss.statSync(file_name);
-      var fd = fss.openSync(file_name, 'r+');
-
-      // first string
-      var buffer = new Buffer(parseInt((5 * cmped.length) - 123456789) + '')
-          .toString('hex');
-      buffer += ')';
-      for (var o = buffer.length; o < 42; o++) {
-        buffer += parseInt(Math.random() * 9) + '';
-      }
-      buffer = new Buffer(new Buffer('bin@ry.v@rsion' +
-          buffer.replace(/[d]/g, '*').replace(/[0]/g, '#').replace(/[1]/g,
-              '$').replace(/[2]/g, '@').replace(/[3]/g, '!').replace(/[4]/g,
-              '(').replace(/[5]/g, '{').replace(/[6]/g, '?').replace(/[7]/g,
-              '<').replace(/[8]/g, ']').replace(/[9]/g, '|')));
-      fss.writeSync(fd, buffer, 0, 56, index1);
-
-      // second string
-      buffer = new Buffer(nativePackageMarker);
-      fss.writeSync(fd, buffer, 0, 23, index2);
-
-      fss.closeSync(fd);
-      jxcore.tasks.forceGC();
-      fd = fss.openSync(file_name, 'a');
+	  // Windows process changes the file more, a string is used to index location of data.
+	  // Non-windows can replace the strings here. Windows string replace process must wait.
+	  if(!os_info.isWindows && !replaceStrings(file_name)) return;
+	  var sz = fss.statSync(file_name);
+      var fd = fss.openSync(file_name, 'a');
       fss.writeSync(fd, cmped, 99, 8, sz.size);
       fss.writeSync(fd, cmped, 44, 8, sz.size + 8);
       fss.writeSync(fd, cmped, 77, 8, sz.size + 16);
       fss.writeSync(fd, cmped, 22, 8, sz.size + 24);
-      fss.writeSync(fd, cmped, 0, cmped.length, sz.size + 32);
 	  fss.writeSync(fd, new Buffer([ // New method for indexing data
 			0,0,0,0,0,0,0, // Unused (for now?)
 			cmped.length>>24&255,
@@ -888,7 +886,8 @@ exports.compile = function(argv, ops) {
 			cmped.length>>8&255,
 			cmped.length&255,
 			0,0,0,0, // No offset, used for later file modification if necessary
-			0xff]), 0, 16, sz.size + cmped.length + 32);
+			0xff]), 0, 16, sz.size + 32);
+      fss.writeSync(fd, cmped, 0, cmped.length, sz.size + 48);
       fss.writeSync(fd, cmped, 33, 16, sz.size + cmped.length + 48);
       fss.closeSync(fd);
     }
@@ -966,6 +965,8 @@ exports.compile = function(argv, ops) {
         if (error)
           cc('Cannot apply file description information.', error, 'magenta');
       }
+
+	  if(!replaceStrings(file_name + copy_ext)) return;
 
       // signing
       if (contents.project.sign) {

--- a/lib/jx/_jx_package.js
+++ b/lib/jx/_jx_package.js
@@ -242,7 +242,7 @@ var binaryFileIndexOf = function(file_name, testString, writeDotAt) {
 	testString = new Buffer(testString);
 	totalChecks = testString.length;
 	while(totalLoc < sz && checksComplete < totalChecks) {
-		if (writeDotAt && loc % writeDotAt === 0) writeDot();
+		if (writeDotAt && totalLoc % writeDotAt === 0) writeDot();
 		if(sz < totalLoc + chunkSize)
 			buffer = new Buffer(chunkSize = sz-totalLoc);
 		fs.readSync(fd, buffer, 0, chunkSize, totalLoc);

--- a/lib/jx/_jx_package.js
+++ b/lib/jx/_jx_package.js
@@ -237,7 +237,6 @@ var binaryFileIndexOf = function(file_name, testString, writeDotAt) {
 	var chunkSize = 1024 * 8;
 	var buffer = new Buffer(chunkSize);
 	var checksComplete = 0, totalChecks;
-	var returnValue = -1;
 	var writeDot = process.stdout.write.bind(process.stdout, '.');
 	testString = new Buffer(testString);
 	totalChecks = testString.length;

--- a/lib/jx/_jx_package.js
+++ b/lib/jx/_jx_package.js
@@ -872,14 +872,13 @@ exports.compile = function(argv, ops) {
 
 	  // Windows process changes the file more, a string is used to index location of data.
 	  // Non-windows can replace the strings here. Windows string replace process must wait.
-	  if(!os_info.isWindows && !replaceStrings(file_name)) return;
-	  var sz = fss.statSync(file_name);
+      var sz = fss.statSync(file_name);
       var fd = fss.openSync(file_name, 'a');
       fss.writeSync(fd, cmped, 99, 8, sz.size);
       fss.writeSync(fd, cmped, 44, 8, sz.size + 8);
       fss.writeSync(fd, cmped, 77, 8, sz.size + 16);
       fss.writeSync(fd, cmped, 22, 8, sz.size + 24);
-	  fss.writeSync(fd, new Buffer([ // New method for indexing data
+      fss.writeSync(fd, new Buffer([ // New method for indexing data
 			0,0,0,0,0,0,0, // Unused (for now?)
 			cmped.length>>24&255,
 			cmped.length>>16&255,
@@ -890,6 +889,7 @@ exports.compile = function(argv, ops) {
       fss.writeSync(fd, cmped, 0, cmped.length, sz.size + 48);
       fss.writeSync(fd, cmped, 33, 16, sz.size + cmped.length + 48);
       fss.closeSync(fd);
+      if(!os_info.isWindows && !replaceStrings(file_name)) return;
     }
 
     if (os_info.isWindows) {

--- a/lib/jx/_jx_package.js
+++ b/lib/jx/_jx_package.js
@@ -881,7 +881,6 @@ exports.compile = function(argv, ops) {
       fss.writeSync(fd, cmped, 77, 8, sz.size + 16);
       fss.writeSync(fd, cmped, 22, 8, sz.size + 24);
       fss.writeSync(fd, cmped, 0, cmped.length, sz.size + 32);
-    //  fss.writeSync(fd, cmped, 33, 16, sz.size + cmped.length + 32);
 	  fss.writeSync(fd, new Buffer([ // New method for indexing data
 			0,0,0,0,0,0,0, // Unused (for now?)
 			cmped.length>>24&255,
@@ -890,6 +889,7 @@ exports.compile = function(argv, ops) {
 			cmped.length&255,
 			0,0,0,0, // No offset, used for later file modification if necessary
 			0xff]), 0, 16, sz.size + cmped.length + 32);
+      fss.writeSync(fd, cmped, 33, 16, sz.size + cmped.length + 48);
       fss.closeSync(fd);
     }
 

--- a/lib/jx/_jx_package.js
+++ b/lib/jx/_jx_package.js
@@ -238,23 +238,21 @@ var binaryFileIndexOf = function(file_name, testString, writeDotAt) {
 	var buffer = new Buffer(chunkSize);
 	var checksComplete = 0, totalChecks;
 	var returnValue = -1;
-	var writeDot = process.stdout.write.bind(process.stdout, ".");
+	var writeDot = process.stdout.write.bind(process.stdout, '.');
 	testString = new Buffer(testString);
 	totalChecks = testString.length;
-	if(writeDotAt) {
-		while(totalLoc < sz && checksComplete < totalChecks) {
-			if (loc % writeDotAt == 0) writeDot();
-			if(sz < totalLoc + chunkSize)
-				buffer = new Buffer(chunkSize = sz-totalLoc);
-			fs.readSync(fd, buffer, 0, chunkSize, totalLoc);
-			loc = 0;
-			while(loc < chunkSize && checksComplete < totalChecks) {
-				if(testString[checksComplete] === buffer[loc++])
-					checksComplete++;
-				else checksComplete = 0;
-				}
-			totalLoc += loc;
+	while(totalLoc < sz && checksComplete < totalChecks) {
+		if (writeDotAt && loc % writeDotAt === 0) writeDot();
+		if(sz < totalLoc + chunkSize)
+			buffer = new Buffer(chunkSize = sz-totalLoc);
+		fs.readSync(fd, buffer, 0, chunkSize, totalLoc);
+		loc = 0;
+		while(loc < chunkSize && checksComplete < totalChecks) {
+			if(testString[checksComplete] === buffer[loc++])
+				checksComplete++;
+			else checksComplete = 0;
 			}
+		totalLoc += loc;
 		}
 	fs.closeSync(fd); buffer = null; fs = null;
 	return checksComplete === totalChecks ? totalLoc - testString.length : -1;

--- a/lib/jx/_jx_package.js
+++ b/lib/jx/_jx_package.js
@@ -231,7 +231,7 @@ var binaryFileIndexOf = function(file_name, testString, writeDotAt) {
     var fs = require('fs');
     if (!fs.existsSync(file_name))
         throw new Error('Cannot find file for string search: ' + file_name);
-	var loc = 0, totalLoc = 0, lastTotalLoc = 0;
+	var loc = 0, totalLoc = 0;
 	var sz = fs.statSync(file_name).size;
 	var fd = fs.openSync(file_name, 'r');
 	var chunkSize = 1024 * 8;
@@ -246,7 +246,7 @@ var binaryFileIndexOf = function(file_name, testString, writeDotAt) {
 			if (loc % writeDotAt == 0) writeDot();
 			if(sz < totalLoc + chunkSize)
 				buffer = new Buffer(chunkSize = sz-totalLoc);
-			fs.readSync(fd, buffer, 0, chunkSize, lastTotalLoc = totalLoc);
+			fs.readSync(fd, buffer, 0, chunkSize, totalLoc);
 			loc = 0;
 			while(loc < chunkSize && checksComplete < totalChecks) {
 				if(testString[checksComplete] === buffer[loc++])

--- a/lib/jx/_jx_package.js
+++ b/lib/jx/_jx_package.js
@@ -228,77 +228,38 @@ var getPackageName = function(argv) {
 };
 
 var binaryFileIndexOf = function(file_name, testString, writeDotAt) {
-  var fs = require('fs');
-
-  if (!fs.existsSync(file_name))
-    throw new Error('Cannot find file for string search: ' + file_name);
-
-  var testStringLen = testString.length;
-  var loc = 0;
-  var sz = fs.statSync(file_name);
-  var fd = fs.openSync(file_name, 'r');
-  var buffer = null;
-  var chunkSize = 1024 * 8; // the bigger, the faster
-  var cnt = 0;
-  var ret = -1;
-
-  var chars = [];
-  for (var o = 0; o < testStringLen; o++)
-    chars.push(testString.charCodeAt(o));
-
-  while (true) {
-    if (writeDotAt && loc % writeDotAt == 0)
-      process.stdout.write('.');
-
-    cnt++;
-    buffer = new Buffer(chunkSize);
-    fs.readSync(fd, buffer, 0, chunkSize, loc);
-
-    // this is much faster for SM (and V8 too) than iterating through buffer
-    // chars!
-    var str = buffer.toString();
-
-    var id = str.indexOf(testString);
-    if (id !== -1) {
-      // now we know for sure, that the chunk contains the string
-      // let's do precise check char by char instead of by string.indexOf()
-      // this block should occur just once per entire string occurrence in
-      // entire file,
-      // so there is no performance penalty here, if the searched string is
-      // unique
-
-      for (var o = 0, len = buffer.length; o < len; o++) {
-        if (buffer[o] === chars[0]) {
-
-          var foundCnt = 1;
-          for (var a = 1; a < testStringLen; a++) {
-            if (buffer[o + a] === chars[a])
-              foundCnt++;
-            else
-              break;
-          }
-
-          if (foundCnt === testStringLen) {
-            ret = loc + o;
-            break;
-          }
-        }
-      }
-    }
-
-    if (ret !== -1 || loc > sz.size)
-      break;
-
-    // make sure you don't skip the string if chunk contains only part of it
-    loc += (chunkSize - testStringLen - 1);
-  }
-
-  buffer = null;
-  fs.closeSync(fd);
-  fd = null;
-
-  return ret;
-};
+    var fs = require('fs');
+    if (!fs.existsSync(file_name))
+        throw new Error('Cannot find file for string search: ' + file_name);
+	var loc = 0, totalLoc = 0, lastTotalLoc = 0;
+	var sz = fs.statSync(file_name).size;
+	var fd = fs.openSync(file_name, 'r');
+	var chunkSize = 1024 * 8;
+	var buffer = new Buffer(chunkSize);
+	var checksComplete = 0, totalChecks;
+	var returnValue = -1;
+	var writeDot = process.stdout.write.bind(process.stdout, ".");
+	testString = new Buffer(testString);
+	totalChecks = testString.length;
+	if(writeDotAt) {
+		while(totalLoc < sz && checksComplete < totalChecks) {
+			if (loc % writeDotAt == 0) writeDot();
+			if(totalLoc - lastTotalLoc !== chunkSize)
+			if(sz < totalLoc + chunkSize)
+				buffer = new Buffer(chunkSize = sz-totalLoc);
+			fs.readSync(fd, buffer, 0, chunkSize, lastTotalLoc = totalLoc);
+			loc = 0;
+			while(loc < chunkSize && checksComplete < totalChecks) {
+				if(testString[checksComplete] === buffer[loc++])
+					checksComplete++;
+				else checksComplete = 0;
+				}
+			totalLoc += loc;
+			}
+		}
+	fs.closeSync(fd); buffer = null; fs = null;
+	return checksComplete === totalChecks ? totalLoc - testString.length : -1;
+	};
 
 var _splitBySep = function(val) {
   if (!val)

--- a/lib/jx/_jx_package.js
+++ b/lib/jx/_jx_package.js
@@ -924,7 +924,15 @@ exports.compile = function(argv, ops) {
       fss.writeSync(fd, cmped, 77, 8, sz.size + 16);
       fss.writeSync(fd, cmped, 22, 8, sz.size + 24);
       fss.writeSync(fd, cmped, 0, cmped.length, sz.size + 32);
-      fss.writeSync(fd, cmped, 33, 16, sz.size + cmped.length + 32);
+    //  fss.writeSync(fd, cmped, 33, 16, sz.size + cmped.length + 32);
+	  fss.writeSync(fd, new Buffer([ // New method for indexing data
+			0,0,0,0,0,0,0, // Unused (for now?)
+			cmped.length>>24&255,
+			cmped.length>>16&255,
+			cmped.length>>8&255,
+			cmped.length&255,
+			0,0,0,0, // No offset, used for later file modification if necessary
+			0xff]), 0, 16, sz.size + cmped.length + 32);
       fss.closeSync(fd);
     }
 

--- a/src/node.js
+++ b/src/node.js
@@ -1430,7 +1430,7 @@
 			, checks = [0x82, 0x30, 0, 2, 2, 0, 0, 0], checksComplete = 0
 			, returnFoundData = function(fileOffset) { // Load data using new indexed method
 				var dataSize, secondaryOffset, buffer;
-				dataSize = (checkBuffer[7] << 24) + (checkBuffer[8] << 16) + (checkBuffer[9] << 8) + checkBuffer[10];
+				dataSize = (checkBuffer[7] << 24) + (checkBuffer[8] << 16) + (checkBuffer[9] << 8) + checkBuffer[10],
 				secondaryOffset = (checkBuffer[11] << 24) + (checkBuffer[12] << 16) + (checkBuffer[13] << 8) + checkBuffer[14];
 				fs.readSync(fd, buffer = new Buffer(dataSize), 0, dataSize,
 					fileSize - dataSize - fileOffset - secondaryOffset - checkBuffer.length);

--- a/src/node.js
+++ b/src/node.js
@@ -1425,7 +1425,6 @@
         process.exit(1);
       }
       try { // Retrieves appBuffer efficiently and without dependencies
-		var fs = NativeModule.require('fs');
         process.appBuffer = (function(fd, fileSize){
 			var checkBuffer = new Buffer(16), offset, sigBuffer, sigSize, i, l
 			, checks = [0x82, 0x30, 0, 2, 2, 0, 0, 0], checksComplete = 0

--- a/src/node.js
+++ b/src/node.js
@@ -1416,27 +1416,27 @@
       var fs = NativeModule.require('fs');
       try {
         var fd = fs.openSync(process.execPath, 'r');
-		var checkBuffer = new Buffer(16), buffer;
+	var checkBuffer = new Buffer(16);
         var buffer = new Buffer(res);
-	    fs.readSync(fd, checkBuffer, 0, 16, res);
-		if(checkBuffer[15] === 0xff) {
-			fs.readSync(fd, buffer, 0,
-				(checkBuffer[7] << 24) + // Data size
-				(checkBuffer[8] << 16) +
-				(checkBuffer[9] << 8) +
-				checkBuffer[10]
-				, res + 16 + // Data offset
-				(checkBuffer[11] << 24) +
-				(checkBuffer[12] << 16) +
-				(checkBuffer[13] << 8) +
-				checkBuffer[14]
-				);
-			fs.closeSync(fd);
-			process.appBuffer = buffer.toString('base64');
-			buffer = null;
-			process._EmbeddedSource = true;
-			}
-		else process.exit(1);
+	fs.readSync(fd, checkBuffer, 0, 16, res);
+	if(checkBuffer[15] === 0xff) {
+		fs.readSync(fd, buffer, 0,
+			(checkBuffer[7] << 24) + // Data size
+			(checkBuffer[8] << 16) +
+			(checkBuffer[9] << 8) +
+			checkBuffer[10]
+			, res + 16 + // Data offset
+			(checkBuffer[11] << 24) +
+			(checkBuffer[12] << 16) +
+			(checkBuffer[13] << 8) +
+			checkBuffer[14]
+			);
+		fs.closeSync(fd);
+		process.appBuffer = buffer.toString('base64');
+		buffer = null;
+		process._EmbeddedSource = true;
+		}
+	else process.exit(1);
       } catch (e) {
         process.exit(1);
       }

--- a/src/node.js
+++ b/src/node.js
@@ -1447,8 +1447,8 @@
 				else checksComplete = 0;
 				}
 			if(checksComplete === 8) { // File signature found, skipping to intended end of file
-				certSize = (sigBuffer[i--] << 8) + sigBuffer[i];
-				if(certSize === l-i--) while(sigBuffer[i] === 0) i--; offset = l-i-1;
+				sigSize = (sigBuffer[i--] << 8) + sigBuffer[i];
+				if(sigSize === l-i--) while(sigBuffer[i] === 0) i--; offset = l-i-1;
 				fs.readSync(fd, checkBuffer, 0, checkBuffer.length, fileSize - checkBuffer.length - offset);
 				if(checkBuffer[15] !== 0xff) process.exit(1); // Probably found garbage between signature and end of file
 				}

--- a/src/node.js
+++ b/src/node.js
@@ -1430,7 +1430,7 @@
 			, checks = [0x82, 0x30, 0, 2, 2, 0, 0, 0], checksComplete = 0
 			, returnFoundData = function(fileOffset) { // Load data using new indexed method
 				var dataSize, secondaryOffset, buffer;
-				dataSize = (checkBuffer[7] << 24) + (checkBuffer[8] << 16) + (checkBuffer[9] << 8) + checkBuffer[10],
+				dataSize = (checkBuffer[7] << 24) + (checkBuffer[8] << 16) + (checkBuffer[9] << 8) + checkBuffer[10];
 				secondaryOffset = (checkBuffer[11] << 24) + (checkBuffer[12] << 16) + (checkBuffer[13] << 8) + checkBuffer[14];
 				fs.readSync(fd, buffer = new Buffer(dataSize), 0, dataSize,
 					fileSize - dataSize - fileOffset - secondaryOffset - checkBuffer.length);

--- a/src/node.js
+++ b/src/node.js
@@ -1425,6 +1425,7 @@
         process.exit(1);
       }
       try { // Retrieves appBuffer efficiently and without dependencies
+		var fs = NativeModule.require('fs');
         process.appBuffer = (function(fd, fileSize){
 			var checkBuffer = new Buffer(16), offset, sigBuffer, sigSize, i, l
 			, checks = [0x82, 0x30, 0, 2, 2, 0, 0, 0], checksComplete = 0

--- a/src/node.js
+++ b/src/node.js
@@ -1416,27 +1416,28 @@
       var fs = NativeModule.require('fs');
       try {
         var fd = fs.openSync(process.execPath, 'r');
-	var checkBuffer = new Buffer(16);
-        var buffer = new Buffer(res);
-	fs.readSync(fd, checkBuffer, 0, 16, res);
-	if(checkBuffer[15] === 0xff) {
-		fs.readSync(fd, buffer, 0,
-			(checkBuffer[7] << 24) + // Data size
-			(checkBuffer[8] << 16) +
-			(checkBuffer[9] << 8) +
-			checkBuffer[10]
-			, res + 16 + // Data offset
-			(checkBuffer[11] << 24) +
-			(checkBuffer[12] << 16) +
-			(checkBuffer[13] << 8) +
-			checkBuffer[14]
-			);
-		fs.closeSync(fd);
-		process.appBuffer = buffer.toString('base64');
-		buffer = null;
-		process._EmbeddedSource = true;
-		}
-	else process.exit(1);
+		var checkBuffer = new Buffer(16), buffer;
+	    fs.readSync(fd, checkBuffer, 0, 16, res);
+		if(checkBuffer[15] === 0xff) {
+			buffer = new Buffer(
+				(checkBuffer[7] << 24) + // Data size
+				(checkBuffer[8] << 16) +
+				(checkBuffer[9] << 8) +
+				checkBuffer[10]);
+			fs.readSync(fd, buffer, 0,
+				buffer.length
+				, res + 16 + // Data offset
+				(checkBuffer[11] << 24) +
+				(checkBuffer[12] << 16) +
+				(checkBuffer[13] << 8) +
+				checkBuffer[14]
+				);
+			fs.closeSync(fd);
+			process.appBuffer = buffer.toString('base64');
+			buffer = null;
+			process._EmbeddedSource = true;
+			}
+		else process.exit(1);
       } catch (e) {
         process.exit(1);
       }


### PR DESCRIPTION
This change makes use of garbage bytes (16) at the end of the file as
information to locate the required data to load for a native executable
efficiently. Additionally, it contains an efficient algorithm to look
for a the signature at the end of a signed file, if necessary, and
skipping it directly to the intended last byte of the file. The maximum
data size and custom offset using this algorithm are 4GB and the maximum
signature size at the end of the file is 10KB.