### PR TITLE
added JX_GetBuffer() to native interface for accessing Buffers directly

### DIFF
--- a/doc/native/Embedding_API_Details.md
+++ b/doc/native/Embedding_API_Details.md
@@ -196,5 +196,9 @@ Wrap a pointer into a JS object
 ##### void JX_UnwrapObject(JXValue *object)
 Unwrap the pointer from a JS object (doesn't remove it)
 
+##### void JX_GetBuffer(JXValue *object)
+Returns a direct pointer to the underlying data for a Buffer. No copying involved.
+Don't hold to it longer than necessary, it may be garbage collected.
+
 ##### void JX_QuitLoop()
 Calls `uv_stop` on thread's uv_loop. Use `LoopOnce` if you need to control the thread.

--- a/src/public/jx_result.cc
+++ b/src/public/jx_result.cc
@@ -267,7 +267,7 @@ JX_GetBuffer(JXValue *value) {
   char *data = NULL;
   RUN_IN_SCOPE({
     if (value->type_ == RT_Buffer) {
-      data = node::Buffer::Data(wrap->value_);
+      data = BUFFER__DATA(wrap->value_);
     }
   });
 

--- a/src/public/jx_result.cc
+++ b/src/public/jx_result.cc
@@ -257,6 +257,23 @@ JX_GetDataLength(JXValue *value) {
   return value->size_;
 }
 
+JXCORE_EXTERN(char *)
+JX_GetBuffer(JXValue *value) {
+  EMPTY_CHECK(NULL);
+
+  UNWRAP_COM(value);
+  UNWRAP_RESULT(value->data_);
+
+  char *data = NULL;
+  RUN_IN_SCOPE({
+    if (value->type_ == RT_Buffer) {
+      data = node::Buffer::Data(wrap->value_);
+    }
+  });
+
+  return data;
+}
+
 JXCORE_EXTERN(void)
 JX_Free(JXValue *value) {
   assert(value != NULL && "JXResult object wasn't initialized");

--- a/src/public/jx_result.h
+++ b/src/public/jx_result.h
@@ -100,13 +100,18 @@ JX_GetDouble(JXValue *value);
 JXCORE_EXTERN(bool)
 JX_GetBoolean(JXValue *value);
 
-// for String, JSON, Error and Buffer
+// for String, JSON, Error
 // call free on return value when you are done with it
 JXCORE_EXTERN(char *)
 JX_GetString(JXValue *value);
 
 JXCORE_EXTERN(int32_t)
 JX_GetDataLength(JXValue *value);
+
+// for Buffer, it returns a direct pointer to the underlying data. no copying involved
+// don't hold to it longer than necessary, it may be gc'd away
+JXCORE_EXTERN(char *)
+JX_GetBuffer(JXValue *value);
 
 JXCORE_EXTERN(void)
 JX_SetInt32(JXValue *value, const int32_t val);

--- a/test/native-interface/direct-buffer/test-posix.cpp
+++ b/test/native-interface/direct-buffer/test-posix.cpp
@@ -1,0 +1,38 @@
+// Copyright & License details are available under JXCORE_LICENSE file
+#include "../commons/common-posix.h"
+
+void callback(JXValue *results, int argc) {
+  // do nothing
+}
+
+
+void sampleMethod(JXValue *params, int argc) {
+  assert(argc == 1 && "previous call did not return correct value");
+  assert(JX_IsBuffer(params+0) && "This method expects a buffer string parameter");
+
+  JXValue *buffer = &params[0];
+  assert(JX_GetDataLength(buffer) == 10000);
+  unsigned char *data = (unsigned char *)JX_GetBuffer(buffer);
+  for (int i = 0 ; i < 10000 ; ++i) {
+    assert(data[i] == (i % 256));
+  }
+  //assert(false);
+}
+
+const char *contents =
+    "var buffer = new Buffer(10000);\n"
+    "for (var i = 0 ; i < buffer.length ; i++) { buffer[i] = i; }\n"
+    "process.natives.sampleMethod(buffer);\n";
+
+int main(int argc, char **args) {
+  JX_Initialize(args[0], callback);
+  JX_InitializeNewEngine();
+
+  JX_DefineMainFile(contents);
+  JX_DefineExtension("sampleMethod", sampleMethod);
+  JX_StartEngine();
+
+  while (JX_LoopOnce() != 0) usleep(1);
+
+  JX_StopEngine();
+}


### PR DESCRIPTION
Hi!

I added JX_GetBuffer() method to directly access contents, and a test case for it (I iterated for both engines 50 times, as asked in TESTING.md).
This facilititates direct&fast access to Buffer’s contents, no copying involved.

Furthermore, as it stands, JX_GetString() does not work for buffers. In the best case, it copies (slow) and terminates on ‘\0’ (incorrect behaviour for a general purpose buffer).
Even the test case return-buffer converts buffer to string with +’’ then expects a string in the native side, which is strange because it means it does not really test buffer access, rather string access. 

Any case, please accept my pull request.

Best Wishes,
Zsolt
 