### PR TITLE
handle zero-length Buffer(0)

### DIFF
--- a/src/public/jx.cc
+++ b/src/public/jx.cc
@@ -71,8 +71,9 @@ JS_LOCAL_METHOD(extensionCallback) {
   }
 
   if (results[len].type_ != RT_Undefined) {
-    assert(results[len].data_ != NULL && (results[len].size_ != 0 ||
-		   results[len].type_ == RT_String) &&
+    assert((results[len].data_ != NULL || (results[len].size_ == 0 && results[len].type_ == RT_Buffer)) &&
+           "Result value is NULL and it is not a zero length buffer");
+    assert((results[len].size_ != 0 || (results[len].type_ == RT_String || results[len].type_ == RT_Buffer)) &&
            "Return value was corrupted");
 
     if (results[len].type_ == RT_Error) {

--- a/src/public/jx_result.cc
+++ b/src/public/jx_result.cc
@@ -523,7 +523,7 @@ JX_SetBuffer(JXValue *value, const char *val, const int32_t length) {
   }
 
   value->type_ = RT_Buffer;
-  value->size_ = length == 0 ? strlen(val) : length;
+  value->size_ = (length == 0 && val != NULL) ? strlen(val) : length;
 
   RUN_IN_SCOPE({
     node::Buffer *buff = node::Buffer::New(val, length, com);

--- a/test/native-interface/return-buffer/test-posix.cpp
+++ b/test/native-interface/return-buffer/test-posix.cpp
@@ -25,12 +25,21 @@ void sampleMethod(JXValue *params, int argc) {
   free(play);
 }
 
+void zeroBuffer(JXValue *params, int argc)
+{
+  // test creating a zero sized bufer
+  JX_SetBuffer(params+argc, nullptr, 0);
+}
+
 const char *contents =
     "var strTest = 'Hello World!';\n"
     "var buffer = process.natives.sampleMethod(strTest);\n"
     "buffer = process.natives.sampleMethod(buffer+'');\n"
     "if(buffer+'' !== strTest) \n"
-    "  process.natives.sampleMethod('', 0);"; // intentionally crash!
+    "  process.natives.sampleMethod('', 0);" // intentionally crash!
+    "var zero = process.natives.zeroBuffer();"
+    "if(zero.length !== 0)"
+    "  process.natives.sampleMethod('', 0);";
 
 int main(int argc, char **args) {
   JX_Initialize(args[0], callback);
@@ -38,6 +47,7 @@ int main(int argc, char **args) {
 
   JX_DefineMainFile(contents);
   JX_DefineExtension("sampleMethod", sampleMethod);
+  JX_DefineExtension("zeroBuffer", zeroBuffer);
   JX_StartEngine();
 
   while (JX_LoopOnce() != 0) usleep(1);


### PR DESCRIPTION
It is a perfectly valid scenario in both Javascript and C/C++ to have a
buffer of zero length, so we must handle this. (strlen(nullptr) would
crash)

Please accept this pull request.

(Ran native test cases with both sm/v8 50 times)

Note that malloc(0) as per the C specs is not guaranteed to return NULL, it either returns NULL or a pointer that must not be dereferenced but can be safely passed to free(). In the latter case, JX_SetBuffer(&value,malloc(0),0) would still crash, so it is a bit unfortunate that len=0 default value corresponds to strlen(), it would be better to have, let’s say -1, but that would break compatibility.

Thanks!

ps: @treasurebox here, changed username just recently.