### PR TITLE
Fix embedding in a Windows non-console app, issue #608.

### DIFF
--- a/doc/api/jxcore-process.markdown
+++ b/doc/api/jxcore-process.markdown
@@ -14,6 +14,10 @@ Attaching any callback to `restart` event, depending on the context in which it 
 
 Internal Recovery is a separate section described [here](jxcore-feature-internal-recovery.markdown).
 
+## process.hasStdFds
+
+This property returns `true` if the environment uses file descriptors 1 & 2 for the   stdout and stderr steams. Used when allocating the console object to determine whether to use standard output streams, or whether to use an alternative (such as for Windows GUI applications).
+
 ## process.isEmbedded
 
 This property returns `true`, if the binary is a static/shared library. This case applies e.g. for mobile deployments (android, iOS).

--- a/lib/console.js
+++ b/lib/console.js
@@ -1,10 +1,10 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
 var util = require('util');
-var isSTD = (process.platform === 'android' || process.platform == 'winrt')
-              && process.isEmbedded;
+var isHeadless = process.isEmbedded && (process.platform === 'android' ||
+              process.platform == 'winrt' || !process.hasStdFds);
 var $tw;
-if (isSTD) {
+if (isHeadless) {
   $tw = process.binding('jxutils_wrap');
 }
 
@@ -12,7 +12,7 @@ function Console(stdout, stderr) {
   if (!(this instanceof Console)) {
     return new Console(stdout, stderr);
   }
-  if (!isSTD) {
+  if (!isHeadless) {
     if (!stdout || typeof stdout.write !== 'function') {
       throw new TypeError('Console expects a writable stream instance');
     }
@@ -49,7 +49,7 @@ Console.prototype.customInterface = function(log_interface, error_interface) {
 };
 
 Console.prototype._log = function(msg) {
-  if (!isSTD) {
+  if (!isHeadless) {
     this._stdout.write(msg);
   } else {
     $tw.print(msg);
@@ -72,7 +72,7 @@ Console.prototype.info = Console.prototype.log;
 
 Console.prototype.warn = function() {
   var msg = util.format.apply(this, arguments) + '\n';
-  if (!isSTD) {
+  if (!isHeadless) {
     this._stderr.write(msg);
   } else {
     $tw.print_err_warn(msg, false);
@@ -88,7 +88,7 @@ Console.prototype.warn = function() {
 
 Console.prototype.error = function() {
   var msg = util.format.apply(this, arguments) + '\n';
-  if (!isSTD) {
+  if (!isHeadless) {
     this._stderr.write(msg);
   } else {
     $tw.print_err_warn(msg, true);
@@ -107,7 +107,7 @@ Console.prototype.dir = function(object, options) {
     customInspect: false
   }, options)) + '\n';
 
-  if (!isSTD) {
+  if (!isHeadless) {
     this._stdout.write(formattedTxt);
   } else {
     $tw.print(formattedTxt);

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,9 +1,9 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-var isSTD = (process.platform === 'android' || process.platform == 'winrt')
-              && process.isEmbedded;
+var isHeadless = process.isEmbedded && (process.platform === 'android' ||
+              process.platform == 'winrt' || !process.hasStdFds);
 var $tw;
-if (isSTD) {
+if (isHeadless) {
   $tw = process.binding('jxutils_wrap');
 }
 
@@ -68,13 +68,13 @@ exports.deprecate = function(fn, msg) {
 exports.print = function() {
   var arr_stream = new Array();
   for (var i = 0, len = arguments.length; i < len; ++i) {
-    if (isSTD)
+    if (isHeadless)
       arr_stream.push(String(arguments[i]));
     else
       process.stdout.write(String(arguments[i]));
   }
 
-  if (isSTD) {
+  if (isHeadless) {
     $tw.print(arr_stream.join(''));
     arr_stream = null;
   }
@@ -82,7 +82,7 @@ exports.print = function() {
 
 exports.puts = function() {
   for (var i = 0, len = arguments.length; i < len; ++i) {
-    if (isSTD)
+    if (isHeadless)
       $tw.print(arguments[i] + '');
     else
       process.stdout.write(arguments[i] + '\n');
@@ -95,7 +95,7 @@ exports.debug = function(x) {
 
 var error = exports.error = function(x) {
   for (var i = 0, len = arguments.length; i < len; ++i) {
-    if (isSTD)
+    if (isHeadless)
       $tw.print(arguments[i] + '\n');
     else
       process.stderr.write(arguments[i] + '\n');

--- a/src/node.cc
+++ b/src/node.cc
@@ -2196,6 +2196,11 @@ void SetupProcessObject(const int threadId) {
   JS_NAME_SET(process, JS_STRING_ID("isEmbedded"), STD_TO_BOOLEAN(false));
 #endif
 
+  // Check if the process has standard stream file descriptors, needed for
+  // allocating a normal console object.
+  JS_NAME_SET(process, JS_STRING_ID("hasStdFds"),
+              STD_TO_BOOLEAN(uv_guess_handle(1) == UV_UNKNOWN_HANDLE));
+
   JS_NAME_SET(process, JS_STRING_ID("isPackaged"),
               STD_TO_BOOLEAN(com->is_packaged_));
 

--- a/src/node.js
+++ b/src/node.js
@@ -1023,10 +1023,10 @@
     var stdin, stdout, stderr;
 
     var util = NativeModule.require('util');
-    var isSTD = (process.platform === 'android' || process.platform == 'winrt')
-                  && process.isEmbedded;
+    var isHeadless = process.isEmbedded && (process.platform === 'android' ||
+	              process.platform == 'winrt' || !process.hasStdFds);
     var $tw;
-    if (isSTD) {
+    if (isHeadless) {
       $tw = process.binding('jxutils_wrap');
     }
 
@@ -1040,7 +1040,7 @@
       Writable.call(this, opt);
     }
 
-    if (isSTD) { // target LogCat for stdout and stderr
+    if (isHeadless) { // target LogCat for stdout and stderr
       fake_stdout = new StdLogCatOut();
       fake_stdout.write = fake_stdout._write = function(bf) {
         $tw.print(bf + '');
@@ -1060,7 +1060,7 @@
     process.__defineGetter__('stdout', function() {
       if (stdout)
         return stdout;
-      if (isSTD) {
+      if (isHeadless) {
         stdout = fake_stdout;
       } else {
         stdout = createWritableStdioStream(1);
@@ -1084,7 +1084,7 @@
       if (stderr)
         return stderr;
 
-      if (isSTD) {
+      if (isHeadless) {
         stderr = fake_stderr;
       } else {
         stderr = createWritableStdioStream(2);
@@ -1102,7 +1102,7 @@
       if (stdin)
         return stdin;
 
-      if (process.isEmbedded && (isSTD || process.platform == 'ios')) {
+      if (process.isEmbedded && (isHeadless || process.platform == 'ios')) {
         console.error('stdin is not supported on embedded applications');
         stdin = fake_stdin;
         // do not throw or return null


### PR DESCRIPTION
Detect when jxcore is running in a Windows GUI, and if so, don't use invalid file handles when allocating the js console object. This prevents an exception with the engine startup, which was stopping the source given to JX_DefineMainFile from running.