### PR TITLE
jxp binary format. Applies to #508, #611

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2341,7 +2341,6 @@ __readFileSync = function(path, encoding) {
       var source = ex_data.readSource('@' + zt, true);
 
       if (ext == '.js') {
-        source = process.binding('jxutils_wrap')._ucmp(source) + '';
         var ind = source.indexOf('return js;});\n');
         if (ind > 0) {
           ind = source.indexOf('\n', ind);

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2338,9 +2338,7 @@ __readFileSync = function(path, encoding) {
         return false;
       }
 
-      var source = ex_data.readSource('@' + zt);
-
-      source = new Buffer(source, 'base64');
+      var source = ex_data.readSource('@' + zt, true);
 
       if (ext == '.js') {
         source = process.binding('jxutils_wrap')._ucmp(source) + '';

--- a/lib/jx/_jx_package.js
+++ b/lib/jx/_jx_package.js
@@ -709,7 +709,49 @@ exports.compile = function(argv, ops) {
       progressDisplayStarted = true;
   };
 
+  // legacy means old packaging method using base64
+  var getFileAndStats = function(filename, legacy) {
+
+    var ret = { doc : null, stat : null };
+    var ext = path.extname(filename).toLowerCase();
+
+    try {
+      var fileBuf = fss.readFileSync(filename);
+      ret.stat = JSON.stringify(fss.statSync(filename));
+
+      if (!legacy) {
+
+        var com = scomp._cmp(fileBuf);
+        fss.appendFileSync(fbuf_name, com);
+        ret.doc = { start : fbuf_len, len : com.length };
+        fbuf_len += com.length;
+        com = null;
+      } else {
+
+        if (ext != '.js')
+          ret.doc = scomp._cmp(fileBuf.toString('base64')).toString('base64');
+        else
+          ret.doc = scomp._cmp(stripBOM(fileBuf + '')).toString('base64');
+      }
+      fileBuf = null;
+    } catch (e) {
+      if (!ret.doc) jxcore.utils.console.error('Cannot read file', filename);
+      if (!ret.stat) jxcore.utils.console.error('Cannot read stat', filename);
+      jxcore.utils.console.error(e);
+      process.exit(1);
+      return false;
+    }
+
+    return ret;
+  };
+
   var caption = jxcore.utils.console.setColor('adding script', 'yellow');
+
+  var legacyPackaging = jxcore.utils.argv.parse().legacy;
+  var fbuf_name = path.join(process.cwd(), "tmpbuf9475628djhf");
+  var fbuf_len = 0;
+  if (fss.existsSync(fbuf_name))
+    fss.unlinkSync(fbuf_name);
 
   var ln_files = proj.files.length;
   for (var i = 0; i < ln_files; i++) {
@@ -719,35 +761,20 @@ exports.compile = function(argv, ops) {
     displayProgress(caption, loc);
     loc = './' + loc;
 
-    var content_sub = null, sub_stat = {};
-    try {
-      content_sub = fss.readFileSync(fn_sub);
-      sub_stat = fss.statSync(fn_sub);
-    } catch (e) {
-      console.log('while processing ', fn_sub, 'red');
-      console.log(e, 'red');
-      process.exit(1);
-    }
-
-    var lo = loc.length - 5;
-    if (lo < 0)
-      lo = 0;
     var ext = path.extname(loc).toLowerCase();
     if (ext != '.json' && ext != '.js') {
       console.log(
-          'only \'js\' or \'json\' files can be defined as a source code. '
-              + '(json and js are case sensitive)', 'red');
+        'only "js" or "json" files can be defined as a source code. '
+        + '(json and js are case sensitive)', 'red');
       process.exit(1);
     }
 
-    var buff;
-    if (path.extname(loc).toLowerCase() != '.js')
-      buff = scomp._cmp(content_sub.toString('base64')).toString('base64');
-    else
-      buff = scomp._cmp(stripBOM(content_sub + '')).toString('base64');
+    var _ret = getFileAndStats(fn_sub, legacyPackaging);
+    if (!_ret) return;
 
-    contents.docs[loc] = buff;
-    contents.stats[loc] = JSON.stringify(sub_stat);
+    contents.docs[loc] = _ret.doc;
+    contents.stats[loc] = _ret.stat;
+    _ret = null;
   }
 
   jxcore.tasks.forceGC();
@@ -782,21 +809,12 @@ exports.compile = function(argv, ops) {
 
       loc = './' + loc;
 
-      var asset_content = null;
-      var _stat = {};
+      var _ret = getFileAndStats(fn, legacyPackaging);
+      if (!_ret) return;
 
-      try {
-        asset_content = fss.readFileSync(fn);
-        _stat = fss.statSync(fn);
-      } catch (e) {
-        console.error(e, 'red');
-        process.exit(1);
-        return;
-      }
-
-      contents.docs[loc] = scomp._cmp(asset_content.toString('base64'))
-          .toString('base64');
-      contents.stats[loc] = JSON.stringify(_stat);
+      contents.docs[loc] = _ret.doc;
+      contents.stats[loc] = _ret.stat;
+      _ret = null;
 
       sizeCheck += contents.docs[loc].length;
       if (i % 50 === 0 || sizeCheck > 1e6) {
@@ -823,40 +841,6 @@ exports.compile = function(argv, ops) {
             + "--extract-what '*.node'");
   }
 
-  if (proj.license_file) {
-    var loc = proj.license_file.trim();
-    var fn = path.resolve(loc);
-    console.log('adding license ' + loc);
-
-    var ct_license = null;
-    try {
-      ct_license = '' + fss.readFileSync(fn);
-    } catch (e) {
-      console.error(e);
-      process.exit();
-      return;
-    }
-
-    contents.license = scomp._cmp(ct_license).toString('base64');
-  }
-
-  if (proj.readme_file) {
-    var loc = proj.readme_file.trim();
-    var fn = path.resolve(loc);
-    console.log('adding readme ' + loc);
-
-    var content = null;
-    try {
-      content = '' + fss.readFileSync(fn);
-    } catch (e) {
-      console.error(e);
-      process.exit();
-      return;
-    }
-
-    contents.readme = scomp._cmp(content).toString('base64');
-  }
-
   var c = JSON.stringify(contents);
   var cmped = scomp._cmp(c);
 
@@ -874,6 +858,12 @@ exports.compile = function(argv, ops) {
       op = op.substr(0, op.length - 3);
     }
   }
+
+  if (!legacyPackaging)
+    cmped = Buffer.concat([cmped, fss.readFileSync(fbuf_name), exports.numberToBuffer(cmped.length), exports.numberToBuffer(cmped.length + 12345)]);
+
+  if (fss.existsSync(fbuf_name))
+    fss.unlinkSync(fbuf_name);
 
   var cc = jxcore.utils.console.log;
   if (contents.project.native) {
@@ -1071,36 +1061,11 @@ exports.compile = function(argv, ops) {
         return;
 
       signFile(contents.project.sign, file_name + copy_ext);
-
-      // signing
-      if (contents.project.sign) {
-        var _cmd = '';
-        var lc = contents.project.sign.toString().toLowerCase();
-        if (lc === 'true') {
-          _cmd = '/a';
-        } else if (fss.existsSync(contents.project.sign)) {
-          _cmd = '/f ' + quote(contents.project.sign);
-        } else {
-          _cmd = contents.project.sign;
-        }
-
-        if (_cmd) {
-          _cmd = 'signtool sign ' + _cmd.trim() + ' ' + quote(finalName);
-          var ret = jxcore.utils.cmdSync(_cmd);
-          if (ret.exitCode) {
-            cc('\nUnable to sign the native package:', 'magenta');
-            cc(ret.out, 'red');
-          } else {
-            cc('\nThe package was successfully signed.', 'yellow');
-          }
-        }
-      }
     }
 
     cc('\n[OK] compiled file is ready (' + file_name + copy_ext + ')',
         !warn_node ? 'green' : '');
   } else {
-    // var str = cmped.toString('base64');
     fss.writeFileSync(op + '.jx', cmped);
     cc('[OK] compiled file is ready (' + contents.project.output + ')',
         !warn_node ? 'green' : '');
@@ -1204,4 +1169,30 @@ exports.isNativePackage = function(file_name) {
   }
 
   return id !== -1;
+};
+
+
+exports.numberToBuffer = function (number) {
+
+  return new Buffer([
+    number >> 32,
+    number >> 24,
+    number >> 16,
+    number >> 8,
+  ]);
+};
+
+// reads 4 bytes
+exports.bufferToNumber = function (buf, offset) {
+
+  if (!offset)
+    offset = 0;
+
+  var ret =
+    (buf[offset + 0] << 32) +
+    (buf[offset + 1] << 24) +
+    (buf[offset + 2] << 16) +
+    (buf[offset + 3] << 8);
+
+  return ret;
 };

--- a/lib/module.js
+++ b/lib/module.js
@@ -874,9 +874,9 @@ getMemContent = function(location) {
 
 _xo = function(_content) {
   var ex = $uw.readSource(_content, true);
-  var _e = jxt._ucmp(ex).toString();
+  var _e = ex ? ex.toString() : '';
   ex = null;
-  return _e;
+  return wrapJS(_content, _e);
 };
 
 // Native extension for .jsonx
@@ -1081,6 +1081,8 @@ var readX = function(m, f, obj, pa, eo) {
     xpName = xpName.replace(' ', '');
   }
 
+  $uw.setSource('~~xpName', xpName);
+
   NativeModule.RootsLength = 1;
 
   var entry_file = pa == undefined || pa == null;
@@ -1216,26 +1218,25 @@ var readX = function(m, f, obj, pa, eo) {
       var __ext = path.extname(o);
       var isJS = __ext === '.js';
       var buff = null;
-      var bufForEmbed = null;
       var legacyPackaging = !obj.binary_packaging;
       if (legacyPackaging) {
         buff = new Buffer(obj.docs[o], 'base64');
         buff = jxt._ucmp(buff);
         // right now buff is still base64 encoded
-        bufForEmbed = new Buffer(buff);
-        // we had so much b64 encoding before...
+        // we had so much base64 encoding before...
         if (!isJS)
           buff = new Buffer(buff.toString(), 'base64');
       } else {
-        var _start = obj.binary_packaging.size + obj.docs[o].start;
-        var b1 = obj.binary_packaging.buffer.slice(_start, _start + obj.docs[o].len);
-        buff = jxt._ucmp(b1);
-        // js files will be compressed, assets will be uncompressed
-        bufForEmbed = isJS ? new Buffer(b1) : new Buffer(buff);
-        b1 = null;
+        var _start = obj.docs[o].start;
+        var _len = obj.docs[o].len;
+        buff = jxt._ucmp(obj.binary_packaging.buffer.slice(_start, _start + _len));
       }
 
       // buff is uncompressed at this point
+      if (!buff) {
+        jxcore.utils.console.error('Error while decompressing:', o);
+        continue;
+      }
 
       if (o === "./package.json") obj.package_json = buff.toString();
       if (o === './' + obj.project.readme_file) obj.readme = buff.toString();
@@ -1243,18 +1244,6 @@ var readX = function(m, f, obj, pa, eo) {
 
       if (__ext == '.js') {
         if (doEmbed) {
-          var keepb = '/*ouvz&tJXPoaQnod*/\n';
-          if (a_embed.indexOf('node_modules') < 0)
-            keepb += "exports.__defineGetter__('$JXP',function(){var " +
-                "js = JSON.parse(process.binding('memory_wrap').readSource('" +
-                xpName + "')); js.bind=function(){}; return js;});\n";
-          var keep = '\n/*mouvz&tJXPoaQnodeJX&vz*/';
-
-
-          var str = buff.toString().replace(/^\#\!.*/, ''); // remove shebang
-          bufForEmbed = jxt._cmp(keepb + str + keep);
-          str = null;
-
           if (!obj.project.fs_reach_sources) {
             $uw.setSource('X@' + a_embed, '1');
           } else {
@@ -1288,7 +1277,8 @@ var readX = function(m, f, obj, pa, eo) {
       }
 
       if (doEmbed) {
-        $uw.setSource('@' + a_embed, bufForEmbed);
+
+        $uw.setSource('@' + a_embed, buff);
         var dn = path.dirname(a_embed);
         var bn = path.basename(a_embed);
 
@@ -1304,7 +1294,7 @@ var readX = function(m, f, obj, pa, eo) {
         if (obj.stats)
           _fnew = new fs.JXStats(null, null, JSON.parse(obj.stats[o]));
         else
-          _fnew = new fs.JXStats(bufForEmbed.length, 33188);
+          _fnew = new fs.JXStats(buff.length, 33188);
 
         for (var o in _fnew) {
           if (!_fnew.hasOwnProperty(o)) continue;
@@ -1314,7 +1304,6 @@ var readX = function(m, f, obj, pa, eo) {
         NativeModule.Roots[dn][bn] = _fstat;
       }
 
-      bufForEmbed = null;
       buff = null;
     }
 
@@ -1947,14 +1936,20 @@ Module._extensions['.jx'] = function(m, f, pa) {
 
   if (legacyPackaging) {
     obj = JSON.parse(jxt._ucmp(buffer, 1));
+    if (!process.noDeprecation) {
+      jxcore.utils.console.warn('Your package was created with older JXcore packaging format ' +
+      'which is currently depreciated and its support will be removed in future JXcore releases.')
+      jxcore.utils.console.log('Don\`t worry, for the moment the package can still be executed.');
+      jxcore.utils.console.log('However we recommend recreating a package ' +
+      'using the latest JXcore version (also for better performance).');
+    }
   } else {
     var _size = firstNumber;
     // the `obj` is just a part of a buffer
     obj = JSON.parse(jxt._ucmp(buffer.slice(0, _size), 1));
-    obj.binary_packaging = {
-      size : _size,
-      buffer : buffer
-    };
+    if (!obj.binary_packaging)
+      obj.binary_packaging = {};
+    obj.binary_packaging.buffer = buffer.slice(_size);
   }
 
   buffer = null;
@@ -1967,4 +1962,25 @@ Module._extensions['.jx'] = function(m, f, pa) {
 
   jxcore.tasks.forceGC();
   return readX(m, f, obj, pa, obj.project.extract);
+};
+
+
+var wrapJS = function(fname, fileSource) {
+
+  var xpName = $uw.readSource('~~xpName');
+
+  if (!xpName)
+    throw "Variable xpName is not defined.";
+
+  fname = fname.replace(process.cwd(), '');
+
+  var keepb = '/*ouvz&tJXPoaQnod*/\n';
+  if (fname.indexOf('node_modules') < 0)
+    keepb += "exports.__defineGetter__('$JXP',function(){var " +
+    "js = JSON.parse(process.binding('memory_wrap').readSource('" +
+    xpName + "')); js.bind=function(){}; return js;});\n";
+  var keep = '\n/*mouvz&tJXPoaQnodeJX&vz*/';
+
+  // also remove shebang
+  return keepb + fileSource.replace(/^\#\!.*/, '') + keep;
 };

--- a/lib/module.js
+++ b/lib/module.js
@@ -642,7 +642,7 @@ Module._extensions['.js'] = function(module, filename, _) {
     if (!$uw.existsSource(filename)) {
       throw new Error("Entry filename wasn't exist (" + filename + ')');
     }
-    content = $uw.readSource(filename);
+    content = $uw.readSource(filename, true).toString();
     delete process.entry_file_name_;
   }
 
@@ -865,7 +865,7 @@ var _loadSub = function() {
 };
 
 getMemContent = function(location) {
-  var data = new Buffer($uw.readSource(location), 'base64');
+  var data = $uw.readSource(location, true);
   var str = data.toString();
   data = null;
 
@@ -873,7 +873,7 @@ getMemContent = function(location) {
 };
 
 _xo = function(_content) {
-  var ex = new Buffer($uw.readSource(_content), 'base64');
+  var ex = $uw.readSource(_content, true);
   var _e = jxt._ucmp(ex).toString();
   ex = null;
   return _e;
@@ -900,7 +900,7 @@ Module.setSourced = function(location, source) {
     dn = path.dirname(location);
 
   if (__mkdirSync(dn))
-    fs.writeFileSync(location, new Buffer(source, 'base64'));
+    fs.writeFileSync(location, source);
 };
 
 var getRelative = function(parent, child) {
@@ -1213,13 +1213,35 @@ var readX = function(m, f, obj, pa, eo) {
         a_embed = getRelative(f, a_embed);
       }
 
-      var buff = new Buffer(obj.docs[o], 'base64');
-      var str = jxt._ucmp(buff).toString();
-      var strForEmbed = str;
-      var strForExtract = str;
       var __ext = path.extname(o);
+      var isJS = __ext === '.js';
+      var buff = null;
+      var bufForEmbed = null;
+      var legacyPackaging = !obj.binary_packaging;
+      if (legacyPackaging) {
+        buff = new Buffer(obj.docs[o], 'base64');
+        buff = jxt._ucmp(buff);
+        // right now buff is still base64 encoded
+        bufForEmbed = new Buffer(buff);
+        // we had so much b64 encoding before...
+        if (!isJS)
+          buff = new Buffer(buff.toString(), 'base64');
+      } else {
+        var _start = obj.binary_packaging.size + obj.docs[o].start;
+        var b1 = obj.binary_packaging.buffer.slice(_start, _start + obj.docs[o].len);
+        buff = jxt._ucmp(b1);
+        // js files will be compressed, assets will be uncompressed
+        bufForEmbed = isJS ? new Buffer(b1) : new Buffer(buff);
+        b1 = null;
+      }
+
+      // buff is uncompressed at this point
+
+      if (o === "./package.json") obj.package_json = buff.toString();
+      if (o === './' + obj.project.readme_file) obj.readme = buff.toString();
+      if (o === './' + obj.project.license_file) obj.license = buff.toString();
+
       if (__ext == '.js') {
-        strForExtract = new Buffer(str).toString('base64');
         if (doEmbed) {
           var keepb = '/*ouvz&tJXPoaQnod*/\n';
           if (a_embed.indexOf('node_modules') < 0)
@@ -1228,10 +1250,10 @@ var readX = function(m, f, obj, pa, eo) {
                 xpName + "')); js.bind=function(){}; return js;});\n";
           var keep = '\n/*mouvz&tJXPoaQnodeJX&vz*/';
 
-          str = str.replace(/^\#\!.*/, ''); // remove shebang
 
-          str = keepb + str + keep;
-          strForEmbed = jxt._cmp(str).toString('base64');
+          var str = buff.toString().replace(/^\#\!.*/, ''); // remove shebang
+          bufForEmbed = jxt._cmp(keepb + str + keep);
+          str = null;
 
           if (!obj.project.fs_reach_sources) {
             $uw.setSource('X@' + a_embed, '1');
@@ -1262,11 +1284,11 @@ var readX = function(m, f, obj, pa, eo) {
         }
 
         if (write)
-          Module.setSourced(a, strForExtract);
+          Module.setSourced(a, buff);
       }
 
       if (doEmbed) {
-        $uw.setSource('@' + a_embed, strForEmbed);
+        $uw.setSource('@' + a_embed, bufForEmbed);
         var dn = path.dirname(a_embed);
         var bn = path.basename(a_embed);
 
@@ -1282,7 +1304,7 @@ var readX = function(m, f, obj, pa, eo) {
         if (obj.stats)
           _fnew = new fs.JXStats(null, null, JSON.parse(obj.stats[o]));
         else
-          _fnew = new fs.JXStats(strForEmbed.length, 33188);
+          _fnew = new fs.JXStats(bufForEmbed.length, 33188);
 
         for (var o in _fnew) {
           if (!_fnew.hasOwnProperty(o)) continue;
@@ -1292,11 +1314,13 @@ var readX = function(m, f, obj, pa, eo) {
         NativeModule.Roots[dn][bn] = _fstat;
       }
 
-      str = null;
-      strForEmbed = null;
-      strForExtract = null;
+      bufForEmbed = null;
       buff = null;
     }
+
+    delete obj.docs;
+    delete obj.binary_packaging;
+    jxcore.tasks.forceGC();
 
     // one-time adding folders not containing any files,
     // but containing sub-folders
@@ -1341,33 +1365,21 @@ var readX = function(m, f, obj, pa, eo) {
   if (entry_file) {
     var exito = false;
     if (process.argv[2] == 'readme') {
-      if (obj.readme) {
-        console.log(jxt._ucmp(new Buffer(obj.readme, 'base64')).toString());
-      } else {
-        console.log("JX file doesn't have a readme definition.\n");
-      }
+      jxcore.utils.console.warn(obj.readme || "JX file doesn't have a readme definition.\n");
       exito = true;
     } else if (process.argv[2] == 'license') {
-      if (obj.license) {
-        console.log(jxt._ucmp(new Buffer(obj.license, 'base64')).toString());
-      } else {
-        jxcore.utils.console.log(
-            "JX file doesn't have a license definition.\n" +
-            "This might be a bug or the package doesn't have a license file." +
-            '\nIf this is a bug, please let us know from support@jxcore.com\n',
-            'green');
-      }
+      jxcore.utils.console.warn(obj.license ||
+        "JX file doesn't have a license definition.\n" +
+        "This might be a bug or the package doesn't have a license file." +
+        '\nIf this is a bug, please let us know from support@jxcore.com\n');
       exito = true;
     }
 
     if (exito) {
       var ww = obj.project.website;
       if (!ww) {
-        if (obj.docs['./package.json']) {
-          var source = obj.docs['./package.json'];
-          source = jxt._ucmp(new Buffer(source, 'base64')).toString();
-          obj.packo = JSON.parse(new Buffer(source, 'base64').toString());
-        }
+        if (obj.package_json)
+          obj.packo = JSON.parse(obj.package_json);
 
         if (obj.packo) {
           if (obj.packo.homepage) {
@@ -1380,7 +1392,7 @@ var readX = function(m, f, obj, pa, eo) {
       if (ww) {
         // partial solution to have this printed on windows when piped
         // (e.g. executed through child_process)
-        var _log = isWindows ? console.warn : console.log;
+        var _log = isWindows ? jxcore.utils.console.warn : jxcore.utils.console.info;
 
         _log('You may want to visit (' + ww +
              ') for more information about the package.');
@@ -1432,8 +1444,6 @@ var readX = function(m, f, obj, pa, eo) {
       return false;
     }
   }
-
-  delete obj.docs[o];
 
   var q = obj.project.startup;
   if (q.length > 3) {
@@ -1923,19 +1933,30 @@ Module._extensions['.jx'] = function(m, f, pa) {
     }
   }
 
-  var con, buffer, ec;
+  var buffer, obj;
   if (!m.fileSource) {
-    con = fs.readFileSync(f);
-    buffer = new Buffer(con);
+    buffer = fs.readFileSync(f);
   } else {
-    ec = m.fileSource;
-    buffer = new Buffer(ec, 'base64');
+    buffer = m.fileSource;
   }
 
-  con = null;
+  var jx_package = require('_jx_package');
+  var firstNumber = jx_package.bufferToNumber(buffer, buffer.length - 8);
+  var secondNumber = jx_package.bufferToNumber(buffer, buffer.length - 4);
+  var legacyPackaging = secondNumber !== firstNumber + 12345;
 
-  var obj = JSON.parse(jxt._ucmp(buffer, 1));
-  ec = null;
+  if (legacyPackaging) {
+    obj = JSON.parse(jxt._ucmp(buffer, 1));
+  } else {
+    var _size = firstNumber;
+    // the `obj` is just a part of a buffer
+    obj = JSON.parse(jxt._ucmp(buffer.slice(0, _size), 1));
+    obj.binary_packaging = {
+      size : _size,
+      buffer : buffer
+    };
+  }
+
   buffer = null;
   if (!obj.project) {
     var err = new Error('Package is either corrupted or not ' +

--- a/src/node.js
+++ b/src/node.js
@@ -1451,7 +1451,7 @@
 				checkBuffer[14]
 				);
 			fs.closeSync(fd);
-			process.appBuffer = buffer.toString('base64');
+			process.appBuffer = buffer;
 			buffer = null;
 			process._EmbeddedSource = true;
 			}


### PR DESCRIPTION
This is implementation for keeping files/assets in binary format (not as base64 strings anymore) inside jx/native packages.

* keeps backwards compatibility:
    * reads previous packages. **I take it as very important.**
    * can also create previous packages if we use `--legacy` option for `jx package`. This is probably not needed to maintain further, but I left this only because literally 4 lines of code are taking care of it and they are easily detachable.
* is much faster now - 60% of previous result duration with bulk operation: creating a package and running/extracting it.
* packages gets also smaller (33% when packing jxcore-cordova-release)
* works on Windows (together with exe signing)
* passes all our tests

**Recent update:**

* during package execution assets are kept in memory store as buffers (no base64/stringify anymore)