### PR TITLE
omit space in version string

### DIFF
--- a/src/node_version.h
+++ b/src/node_version.h
@@ -41,9 +41,9 @@
 
 #ifdef JS_ENGINE_MOZJS
 #define MOZJS_VERSION 34
-#define JXCORE_VERSION "v " JXCORE_VERSION_STRING
+#define JXCORE_VERSION "v" JXCORE_VERSION_STRING
 #else
-#define JXCORE_VERSION "v " JXCORE_VERSION_STRING
+#define JXCORE_VERSION "v" JXCORE_VERSION_STRING
 #endif
 
 #define NODE_VERSION_AT_LEAST(major, minor, patch)                  \


### PR DESCRIPTION
prior art:

``` sh
$ node -v
v0.10.40
$ npm -v
1.4.14
```

Personally, I would be okay with dropping the `v` entirely, but at the very least, removing the space would be beneficial. Aside from not following convention, the version string seems to be used as the lockfile name for npm. Which means jx is writing a file with a space in the name; that's just not nice. :)

(change made on github, untested)