### PR TITLE
jxcore: moved node::removeCommons() outside AutoScope scope

### DIFF
--- a/src/jxcore.cc
+++ b/src/jxcore.cc
@@ -1063,6 +1063,7 @@ void JXEngine::InitializeEmbeddedEngine(int argc, char **argv) {
 
 void JXEngine::Destroy() {
   ENGINE_LOG_THIS("JXEngine", "Destroy");
+  {
   AutoScope _scope_(this, true);
   {
     customLock(CSLOCK_JOBS);
@@ -1109,7 +1110,7 @@ void JXEngine::Destroy() {
   jx_engine_map::iterator it = jx_engine_instances.find(main_node_->threadId);
   if (it != jx_engine_instances.end()) jx_engine_instances.erase(it);
   customUnlock(CSLOCK_JOBS);
-
+  }
   node::removeCommons();
 }
 #endif


### PR DESCRIPTION
When the AutoScope object goes out of scope in the JXEngine::Destroy method it uses members of main_node_ that prior to this fix had already been destroyed by the node::removeCommons() call. This fix moves the node::removeCommons autoside the lifetime scope of the AutoScope object, such that it's guaranteed that all members of main_node_ are still dereferenceable.