### PR TITLE
adding pre-shared-key (psk) support for tls

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -33,6 +33,16 @@ function toBuf(str, encoding) {
   return str;
 }
 
+var debug;
+if (process.env.NODE_DEBUG && /crypto/.test(process.env.NODE_DEBUG)) {
+  debug = function (a) {
+    console.error('CRYPTO:', a);
+  };
+} else {
+  debug = function () {
+  };
+}
+
 var assert = require('assert');
 var StringDecoder = require('string_decoder').StringDecoder;
 
@@ -151,6 +161,15 @@ exports.createCredentials = function(options, context) {
     } else {
       c.context.loadPKCS12(pfx);
     }
+  }
+
+  if (options.pskServerCallback) {
+    debug('a psk call back provider');
+    c.context.setPskServerCallback(options.pskServerCallback);
+  }
+
+  if (options.pskServerHint) {
+    c.context.setPskHint(options.pskServerHint);
   }
 
   return c;

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -13,6 +13,7 @@ var constants = require('constants');
 var Timer = process.binding('timer_wrap').Timer;
 
 var DEFAULT_CIPHERS = 'ECDHE-RSA-AES128-SHA256:AES128-GCM-SHA256:' + // TLS 1.2
+                      'PSK-AES256-CBC-SHA:PSK-3DES-EDE-CBC-SHA:PSK-AES128-CBC-SHA:' + //PSK adding to default ciphers
                       'RC4:HIGH:!MD5:!aNULL:!EDH';                   // TLS 1.0
 
 // Allow {CLIENT_RENEG_LIMIT} client-initiated session renegotiations
@@ -860,6 +861,11 @@ function SecurePair(credentials, isServer, requestCert, rejectUnauthorized,
     this.ssl.setNPNProtocols(options.NPNProtocols);
     this.npnProtocol = null;
   }
+  
+   // PSK 
+  if (options.pskClientCallback) {
+    this.ssl.setPskClientCallback(options.pskClientCallback);
+  }
 
   /* Acts as a r/w stream to the cleartext side of the stream. */
   this.cleartext = new CleartextStream(this, options.cleartext);
@@ -889,11 +895,13 @@ util.inherits(SecurePair, events.EventEmitter);
 exports.createSecurePair = function(credentials,
                                     isServer,
                                     requestCert,
-                                    rejectUnauthorized) {
+                                    rejectUnauthorized,
+                                    pskCallback) {
   var pair = new SecurePair(credentials,
                             isServer,
                             requestCert,
-                            rejectUnauthorized);
+                            rejectUnauthorized,
+                            pskCallback ? { pskCallback: pskCallback  } : null);
   return pair;
 };
 
@@ -957,7 +965,9 @@ SecurePair.prototype.error = function(returnOnly) {
   return err;
 };
 
-// TODO: support anonymous (nocert) and PSK
+
+
+// TODO: support anonymous (nocert)
 
 // AUTHENTICATION MODES
 //
@@ -1064,7 +1074,9 @@ function Server(/* [options], listener */) {
     secureProtocol: self.secureProtocol,
     secureOptions: self.secureOptions,
     crl: self.crl,
-    sessionIdContext: self.sessionIdContext
+    sessionIdContext: self.sessionIdContext,
+    pskServerCallback: self.pskCallback,
+    pskServerHint: self.pskHint    
   });
 
   var timeout = options.handshakeTimeout || (120 * 1000);
@@ -1089,8 +1101,9 @@ function Server(/* [options], listener */) {
                               {
                                 server: self,
                                 NPNProtocols: self.NPNProtocols,
-                                SNICallback: self.SNICallback,
-
+                                //setting here as even with PSK default cb is called
+                                //see node_crypto.cc:1161:int Connection::SelectSNIContextCallback_(SSL* s, int* ad, void* arg)
+                                SNICallback: self.isPskServer ? null : self.SNICallback,
                                 // Stream options
                                 cleartext: self._cleartext,
                                 encrypted: self._encrypted
@@ -1114,25 +1127,34 @@ function Server(/* [options], listener */) {
       pair.cleartext.npnProtocol = pair.npnProtocol;
       pair.cleartext.servername = pair.servername;
 
-      if (!self.requestCert) {
+      if (pair.ssl.pskIdentity) {
+        debug('psk identity provided');
+        pair.cleartext.pskIdentity = pair.ssl.pskIdentity;
+        pair.cleartext.authorized = true;
         cleartext._controlReleased = true;
         self.emit('secureConnection', pair.cleartext, pair.encrypted);
-      } else {
-        var verifyError = pair.ssl.verifyError();
-        if (verifyError) {
-          pair.cleartext.authorizationError = verifyError.message;
+      }
+      else {
+        if (!self.requestCert) {
+          cleartext._controlReleased = true;
+          self.emit('secureConnection', pair.cleartext, pair.encrypted);
+        } else {
+          var verifyError = pair.ssl.verifyError();
+          if (verifyError) {
+            pair.cleartext.authorizationError = verifyError.message;
 
-          if (self.rejectUnauthorized) {
-            socket.destroy();
-            pair.destroy();
+            if (self.rejectUnauthorized) {
+              socket.destroy();
+              pair.destroy();
+            } else {
+              cleartext._controlReleased = true;
+              self.emit('secureConnection', pair.cleartext, pair.encrypted);
+            }
           } else {
+            pair.cleartext.authorized = true;
             cleartext._controlReleased = true;
             self.emit('secureConnection', pair.cleartext, pair.encrypted);
           }
-        } else {
-          pair.cleartext.authorized = true;
-          cleartext._controlReleased = true;
-          self.emit('secureConnection', pair.cleartext, pair.encrypted);
         }
       }
     });
@@ -1164,6 +1186,19 @@ Server.prototype.setOptions = function(options) {
   } else {
     this.rejectUnauthorized = false;
   }
+  
+  if (options.pskCallback && !options.ciphers) {
+    // set default PSK ciphers if it looks like we're trying to use
+    // PSK but no preference has been specified
+    debug('using PSK and setting default ciphers');
+    options.ciphers = DEFAULT_CIPHERS;
+  }
+  
+  if (options.pskCallback) {
+    this.pskCallback = options.pskCallback;
+    this.isPskServer = true;
+  }
+  if (options.pskHint) this.pskHint = options.pskHint;
 
   if (options.pfx) this.pfx = options.pfx;
   if (options.key) this.key = options.key;
@@ -1226,6 +1261,9 @@ Server.prototype.SNICallback = function(servername) {
   return ctx;
 };
 
+
+
+
 // Target API:
 //
 // var s = tls.connect({port: 8000, host: "google.com"}, function() {
@@ -1266,6 +1304,35 @@ exports.connect = function(/* [port, host], options, cb */) {
 
   options.secureOptions = crypto._getSecureOptions(options.secureProtocol,
                                                    options.secureOptions);
+  
+  var hasPskCallback = !!(options.pskClientCallback);
+  var isPskIdentity = !!(options.pskIdentity && options.pskKey);
+  
+  // if a PSK identity/key pair was provided, translate it into the
+  // callback expected by SecurePair
+  if (isPskIdentity) {
+    debug('### we are working with psk');
+    if (!hasPskCallback) {
+      options.pskClientCallback = function (hint) {
+        return {
+          identity: options.pskIdentity,
+          key: options.pskKey
+        }
+      };
+      hasPskCallback = true;
+    }
+    else {
+      debug('both a pskClientCallback and (pskIdentity&pskKey) provided - which is illogical');
+      debug('at this point - only the pskClientCallback is going to be used.')
+    }
+  }
+
+  if (hasPskCallback && !options.ciphers) {
+    // set default PSK ciphers if it looks like we're trying to use
+    // PSK but no preference has been specified
+    debug('### using Default ciphers... ');
+    options.ciphers = DEFAULT_CIPHERS;
+  }
 
   var socket = options.socket ? options.socket : new net.Stream();
 
@@ -1280,7 +1347,8 @@ exports.connect = function(/* [port, host], options, cb */) {
                               NPNProtocols: NPN.NPNProtocols,
                               servername: hostname,
                               cleartext: options.cleartext,
-                              encrypted: options.encrypted
+                              encrypted: options.encrypted,
+                              pskClientCallback: options.pskClientCallback
                             });
 
   if (options.session) {
@@ -1306,33 +1374,38 @@ exports.connect = function(/* [port, host], options, cb */) {
   }
 
   pair.on('secure', function() {
-    var verifyError = pair.ssl.verifyError();
-
     cleartext.npnProtocol = pair.npnProtocol;
-
-    // Verify that server's identity matches it's certificate's names
-    if (!verifyError) {
-      var validCert = checkServerIdentity(hostname,
-                                          pair.cleartext.getPeerCertificate());
-      if (!validCert) {
-        verifyError = new Error('Hostname/IP doesn\'t match certificate\'s ' +
-                                'altnames');
-      }
-    }
-
-    if (verifyError) {
-      cleartext.authorized = false;
-      cleartext.authorizationError = verifyError.message;
-
-      if (pair._rejectUnauthorized) {
-        cleartext.emit('error', verifyError);
-        pair.destroy();
-      } else {
-        cleartext.emit('secureConnect');
-      }
-    } else {
+    
+    if (hasPskCallback) {
+      cleartext.pskIdentity = pair.ssl.pskIdentity;
       cleartext.authorized = true;
       cleartext.emit('secureConnect');
+    }
+    else {
+      var verifyError = pair.ssl.verifyError();
+      // Verify that server's identity matches it's certificate's names
+      if (!verifyError) {
+        var validCert = checkServerIdentity(hostname,
+                                          pair.cleartext.getPeerCertificate());
+        if (!validCert) {
+          verifyError = new Error('Hostname/IP doesn\'t match certificate\'s ' +
+                                'altnames');
+        }
+      }
+      if (verifyError) {
+        cleartext.authorized = false;
+        cleartext.authorizationError = verifyError.message;
+        
+        if (pair._rejectUnauthorized) {
+          cleartext.emit('error', verifyError);
+          pair.destroy();
+        } else {
+          cleartext.emit('secureConnect');
+        }
+      } else {
+        cleartext.authorized = true;
+        cleartext.emit('secureConnect');
+      }
     }
   });
   pair.on('error', function(err) {
@@ -1342,6 +1415,9 @@ exports.connect = function(/* [port, host], options, cb */) {
   cleartext._controlReleased = true;
   return cleartext;
 };
+
+
+
 
 function pipe(pair, socket) {
   pair.encrypted.pipe(socket);

--- a/test/simple/test-tls-psk-circuit.js
+++ b/test/simple/test-tls-psk-circuit.js
@@ -1,0 +1,132 @@
+// Copyright Joyent, Inc. and other Node contributors.
+
+if (!process.versions.openssl) {
+  console.error("Skipping because node compiled without OpenSSL.");
+  process.exit(0);
+}
+if (parseInt(process.versions.openssl[0]) < 1) {
+  console.error("Skipping because node compiled with old OpenSSL version.");
+  process.exit(0);
+}
+
+var common = require('../common');
+var assert = require('assert');
+var fs = require('fs');
+var tls = require('tls');
+
+var serverPort = common.PORT;
+
+var serverResults = [];
+var clientResults = [];
+var connectingIds = [];
+
+var users = {
+  UserA: new Buffer("d731ef57be09e5204f0b205b60627028", 'hex'),
+  UserB: new Buffer("82072606b502b0f4025e90eb75fe137d", 'hex')
+};
+
+function filenamePEM(n) {
+  return require('path').join(common.fixturesDir, 'keys', n + '.pem');
+}
+
+function loadPEM(n) {
+  return fs.readFileSync(filenamePEM(n));
+
+}
+
+var serverOptions = {
+  // configure a mixed set of cert and PSK ciphers
+  ciphers: 'RC4-SHA:AES128-SHA:AES256-SHA:PSK-AES256-CBC-SHA:PSK-3DES-EDE-CBC-SHA:PSK-AES128-CBC-SHA:PSK-RC4-SHA',
+  pskCallback: function (id) {
+    connectingIds.push(id);
+    if (id in users) {
+      return users[id];
+    }
+  },
+  key: loadPEM('agent2-key'),
+  cert: loadPEM('agent2-cert')
+  //SNICallback: function (servername, cb) {
+    
+  //  return true;
+  //}
+};
+
+var clientOptions = [{
+    pskIdentity: 'UserA',
+    pskKey: users.UserA
+  }, {
+    pskIdentity: 'UserB',
+    pskKey: users.UserB
+  }, {
+    pskIdentity: 'UserC',   // unrecognized user should fail handshake
+    pskKey: users.UserB
+  }, {
+    pskIdentity: 'UserB',   // recognized user but incorrect secret should fail handshake
+    pskKey: new Buffer("025e90eb75fe137d82072606b502b0f4", 'hex')
+  }, {
+    pskIdentity: 'UserB',
+    pskKey: users.UserB
+  }
+];
+
+var server = tls.createServer(serverOptions, function (c) {
+  console.log('%s connected', c.pskIdentity);
+  serverResults.push(c.pskIdentity + ' ' + (c.authorized ? 'authorized' : 'not authorized'));
+  c.once('data', function (data) {
+    assert.equal(data.toString(), 'Hi.');
+    c.write('Hi ' + c.pskIdentity);
+    c.once('data', function (data) {
+      assert.equal(data.toString(), 'Bye.');
+    });
+  });
+});
+
+server.listen(serverPort, startTest);
+
+function startTest() {
+  function connectClient(options, callback) {
+    console.log('connecting as %s', options.pskIdentity);
+    var client = tls.connect(serverPort, 'localhost', options, function () {
+      clientResults.push(client.pskIdentity + ' ' + (client.authorized ? 'authorized' : 'not authorized'));
+      client.write('Hi.');
+      client.on('data', function (data) {
+        assert.equal(data.toString(), 'Hi ' + options.pskIdentity);
+        client.end('Bye.');
+      });
+      callback();
+    });
+    client.on('error', function (err) {
+      console.log('connection as %s rejected', options.pskIdentity);
+      clientResults.push(err.message);
+      callback(err);
+    });
+  }
+  
+  function doTestCase(tcnum) {
+    if (tcnum >= clientOptions.length) {
+      server.close();
+    } else {
+      connectClient(clientOptions[tcnum], function (err) {
+        doTestCase(tcnum + 1);
+      });
+    }
+  }
+  doTestCase(0);
+
+}
+
+process.on('exit', function () {
+  assert.deepEqual(serverResults, ['UserA authorized',
+    'UserB authorized',
+    'UserB authorized']);
+  assert.deepEqual(clientResults, ['UserA authorized',
+    'UserB authorized',
+    'socket hang up',
+    'socket hang up',
+    'UserB authorized']);
+  assert.deepEqual(connectingIds, ['UserA',
+    'UserB',
+    'UserC',
+    'UserB',
+    'UserB']);
+});

--- a/test/simple/test-tls-psk-client-callback.js
+++ b/test/simple/test-tls-psk-client-callback.js
@@ -1,0 +1,101 @@
+// Copyright Joyent, Inc. and other Node contributors.
+
+if (!process.versions.openssl) {
+  console.error("Skipping because node compiled without OpenSSL.");
+  process.exit(0);
+}
+if (parseInt(process.versions.openssl[0]) < 1) {
+  console.error("Skipping because node compiled with old OpenSSL version.");
+  process.exit(0);
+}
+
+/* This will test a client using JUST a callback - in place of 
+ * both a Identity & Key
+ *
+*/
+
+var common = require('../common');
+var assert = require('assert');
+var fs = require('fs');
+var tls = require('tls');
+
+var serverPort = common.PORT;
+
+var serverResults = [];
+var clientResults = [];
+
+
+var identity = "TestUser";
+var pskKey = new Buffer("d731ef57be09e5204f0b205b60627028", 'hex');
+
+var clientCallback = function () {
+  return {
+    identity: identity,
+    key: pskKey
+  }
+}
+
+
+//server ALWAYS requires cert regardles if not using
+function filenamePEM(n) {
+  return require('path').join(common.fixturesDir, 'keys', n + '.pem');
+}
+
+function loadPEM(n) {
+  return fs.readFileSync(filenamePEM(n));
+}
+
+var serverOptions = {
+  // configure a mixed set of cert and PSK ciphers
+  ciphers: 'RC4-SHA:AES128-GCM-SHA256:AES128-SHA:AES256-SHA:PSK-AES256-CBC-SHA:PSK-3DES-EDE-CBC-SHA:PSK-AES128-CBC-SHA:PSK-RC4-SHA',
+  pskCallback: function (id) {
+    assert(id == identity);
+    return pskKey ;
+  },
+  key: loadPEM('agent2-key'),
+  cert: loadPEM('agent2-cert')
+};
+
+var server = tls.createServer(serverOptions, function (c) {
+  console.log('%s connected', c.pskIdentity);
+  serverResults.push(c.pskIdentity + ' ' + (c.authorized ? 'authorized' : 'not authorized'));
+  c.once('data', function (data) {
+    assert.equal(data.toString(), 'Hi.');
+    c.write('Hi ' + c.pskIdentity);
+    c.once('data', function (data) {
+      assert.equal(data.toString(), 'Bye.');
+    });
+  });
+});
+
+server.listen(serverPort, startTest);
+
+var options = {};
+options.pskClientCallback = clientCallback;
+options.ciphers = 'PSK-AES256-CBC-SHA:PSK-3DES-EDE-CBC-SHA';
+
+function startTest() {
+  console.log('connecting with callback.. %s', identity);
+  var client = tls.connect(serverPort, 'localhost', options, function () {
+    clientResults.push(client.pskIdentity + ' ' + (client.authorized ? 'authorized' : 'not authorized'));
+    client.write('Hi.');
+    client.on('data', function (data) {
+      assert.equal(data.toString(), 'Hi ' + identity);
+      client.end('Bye.');
+      server.close();
+
+    });
+  });
+  client.on('error', function (err) {
+    console.log('connection as %s rejected', identity);
+    clientResults.push(err.message);
+  });
+}
+
+
+process.on('exit', function () {
+  assert.deepEqual(serverResults, [
+    'TestUser authorized']);
+  assert.deepEqual(clientResults, [
+    'TestUser authorized']);
+});

--- a/test/simple/test-tls-psk-client-identity-key.js
+++ b/test/simple/test-tls-psk-client-identity-key.js
@@ -1,0 +1,99 @@
+// Copyright Joyent, Inc. and other Node contributors.
+
+if (!process.versions.openssl) {
+  console.error("Skipping because node compiled without OpenSSL.");
+  process.exit(0);
+}
+if (parseInt(process.versions.openssl[0]) < 1) {
+  console.error("Skipping because node compiled with old OpenSSL version.");
+  process.exit(0);
+}
+
+/* This will test a client using both Identity and Key - in place of 
+ * a Client Callback
+ *
+*/
+
+
+/* This will test a client failure if just a Identity OR just a Key
+ * and no Client Callback
+*/
+
+var common = require('../common');
+var assert = require('assert');
+var fs = require('fs');
+var tls = require('tls');
+
+var serverPort = common.PORT;
+
+var serverResults = [];
+var clientResults = [];
+
+
+var identity = "TestUser";
+var pskKey = new Buffer("d731ef57be09e5204f0b205b60627028", 'hex');
+
+//server ALWAYS requires cert regardles if not using
+function filenamePEM(n) {
+  return require('path').join(common.fixturesDir, 'keys', n + '.pem');
+}
+
+function loadPEM(n) {
+  return fs.readFileSync(filenamePEM(n));
+}
+
+var serverOptions = {
+  // configure a mixed set of cert and PSK ciphers
+  ciphers: 'RC4-SHA:AES128-GCM-SHA256:AES128-SHA:AES256-SHA:PSK-AES256-CBC-SHA:PSK-3DES-EDE-CBC-SHA:PSK-AES128-CBC-SHA:PSK-RC4-SHA',
+  pskCallback: function (id) {
+    assert(id == identity);
+    return pskKey ;
+  },
+  key: loadPEM('agent2-key'),
+  cert: loadPEM('agent2-cert')
+};
+
+var server = tls.createServer(serverOptions, function (c) {
+  console.log('%s connected', c.pskIdentity);
+  serverResults.push(c.pskIdentity + ' ' + (c.authorized ? 'authorized' : 'not authorized'));
+  c.once('data', function (data) {
+    assert.equal(data.toString(), 'Hi.');
+    c.write('Hi ' + c.pskIdentity);
+    c.once('data', function (data) {
+      assert.equal(data.toString(), 'Bye.');
+    });
+  });
+});
+
+server.listen(serverPort, startTest);
+
+var options = {};
+options.pskIdentity = identity;
+options.pskKey = pskKey;
+options.ciphers = 'PSK-AES256-CBC-SHA:PSK-3DES-EDE-CBC-SHA';
+
+function startTest() {
+  console.log('connecting with callback.. %s', identity);
+  var client = tls.connect(serverPort, 'localhost', options, function () {
+    clientResults.push(client.pskIdentity + ' ' + (client.authorized ? 'authorized' : 'not authorized'));
+    client.write('Hi.');
+    client.on('data', function (data) {
+      assert.equal(data.toString(), 'Hi ' + identity);
+      client.end('Bye.');
+      server.close();
+
+    });
+  });
+  client.on('error', function (err) {
+    console.log('connection as %s rejected', identity);
+    clientResults.push(err.message);
+  });
+}
+
+
+process.on('exit', function () {
+  assert.deepEqual(serverResults, [
+    'TestUser authorized']);
+  assert.deepEqual(clientResults, [
+    'TestUser authorized']);
+});

--- a/test/simple/test-tls-psk-client-identity-nokey.js
+++ b/test/simple/test-tls-psk-client-identity-nokey.js
@@ -1,0 +1,83 @@
+// Copyright Joyent, Inc. and other Node contributors.
+
+if (!process.versions.openssl) {
+  console.error("Skipping because node compiled without OpenSSL.");
+  process.exit(0);
+}
+if (parseInt(process.versions.openssl[0]) < 1) {
+  console.error("Skipping because node compiled with old OpenSSL version.");
+  process.exit(0);
+}
+
+/* This will test a client using both Identity and NO Key - in place of 
+ * a Client Callback
+ *
+*/
+
+
+var common = require('../common');
+var assert = require('assert');
+var fs = require('fs');
+var tls = require('tls');
+
+var serverPort = common.PORT;
+
+var serverResults = [];
+var clientResults = [];
+
+
+var identity = "TestUser";
+
+//server ALWAYS requires cert regardles if not using
+function filenamePEM(n) {
+  return require('path').join(common.fixturesDir, 'keys', n + '.pem');
+}
+
+function loadPEM(n) {
+  return fs.readFileSync(filenamePEM(n));
+}
+
+var serverOptions = {
+  // configure a mixed set of cert and PSK ciphers
+  ciphers: 'RC4-SHA:AES128-GCM-SHA256:AES128-SHA:AES256-SHA:PSK-AES256-CBC-SHA:PSK-3DES-EDE-CBC-SHA:PSK-AES128-CBC-SHA:PSK-RC4-SHA',
+  pskCallback: function (id) {
+    assert(id == identity);
+    return pskKey ;
+  },
+  key: loadPEM('agent2-key'),
+  cert: loadPEM('agent2-cert')
+};
+
+var server = tls.createServer(serverOptions, function (c) {
+  console.log('%s connected', c.pskIdentity);
+});
+
+server.listen(serverPort, startTest);
+
+var options = {};
+options.pskIdentity = identity;
+options.ciphers = 'PSK-AES256-CBC-SHA:PSK-3DES-EDE-CBC-SHA';
+
+function startTest() {
+  console.log('connecting with callback.. %s', identity);
+  var client = tls.connect(serverPort, 'localhost', options, function () {
+    client.on('data', function (data) {
+      assert()      
+      client.end('Bye.');
+      server.close();
+    });
+  });
+  client.on('error', function (err) {
+    console.log('connection as %s rejected', identity);
+    clientResults.push("connection rejected");
+    console.log(err.message);
+    serverResults.push(err.message);
+    server.close();
+  });
+}
+
+process.on('exit', function () {
+  assert.deepEqual(clientResults, [
+    'connection rejected']);
+  assert(/error/g.test(serverResults[0]));
+});

--- a/test/simple/test-tls-psk-client.js
+++ b/test/simple/test-tls-psk-client.js
@@ -1,0 +1,213 @@
+// Copyright & License details are available under JXCORE_LICENSE file
+
+if (process.env.CITEST) {
+    console.error('Skipping test due to CITEST environment variable. (old openssl.exe)');
+    process.exit(0);
+}
+if (!process.versions.openssl) {
+    console.error("Skipping because node compiled without OpenSSL.");
+    process.exit(0);
+}
+if (parseInt(process.versions.openssl[0]) < 1) {
+    console.error("Skipping because node compiled with old OpenSSL version.");
+    process.exit(0);
+}
+
+var common = require('../common');
+var join = require('path').join;
+var net = require('net');
+var assert = require('assert');
+var fs = require('fs');
+var crypto = require('crypto');
+var tls = require('tls');
+var spawn = require('child_process').spawn;
+var exec = require('child_process').exec;
+
+// versions of openssl do not support PSK
+// Therefore we skip this
+// test for all openssl versions less than 1.0.0.
+function checkOpenSSL() {
+  exec('openssl version', function(err, data) {;
+    if (err) throw err;
+    if (/OpenSSL 0\./.test(data)) {
+      console.error('Skipping due to old OpenSSL version.');
+      return false;
+    }
+    else {
+      return true;
+    }
+  });
+}
+
+if (! checkOpenSSL()){
+  console.error("Skipping because OpenSSL version < 1.0.0.");
+  process.exit(0)
+}
+
+
+
+// FIXME: Avoid the common PORT as this test currently hits a C-level
+// assertion error with node_g. The program aborts without HUPing
+// the openssl s_server thus causing many tests to fail with
+// EADDRINUSE.
+var PORT = common.PORT + 5;
+
+var pskey = "d731ef57be09e5204f0b205b60627028";
+var identity = 'Client_identity';   // openssl s_client supports specifying the identity but s_server, oddly, does not
+
+var sharedHint = "foobar";
+
+var PSKCiphers = 'PSK-AES256-CBC-SHA:PSK-3DES-EDE-CBC-SHA:PSK-AES128-CBC-SHA:PSK-RC4-SHA';
+
+
+var useTestServer = false; //set to true to use external openssl s_server instance...
+var forcedClosed = false;
+
+var gotWriteCallback = false;
+var serverExitCode = -1;
+
+if (!useTestServer) {
+    var server = spawn('openssl', ['s_server',
+        '-accept', PORT,
+        '-psk', pskey,
+        '-psk_hint', sharedHint,
+        '-nocert']);
+    server.stdout.pipe(process.stdout);
+    server.stderr.pipe(process.stdout);
+    //server.stdin.pipe(process.stdin);
+
+    if (server.stdin) console.log('exists');
+
+    var state = 'WAIT-ACCEPT';
+
+    var serverStdoutBuffer = '';
+    server.stdout.setEncoding('utf8');
+    server.stdin.setEncoding('utf8');
+    
+    server.stdout.on('data', function (s) {
+        serverStdoutBuffer += s;
+        console.error(state);
+        switch (state) {
+            case 'WAIT-ACCEPT':
+                if (/ACCEPT/g.test(serverStdoutBuffer)) {
+                    // Give s_server a second to start up.
+                    setTimeout(startClient, 500);
+                    state = 'WAIT-HELLO';
+                }
+                break;
+
+            case 'WAIT-HELLO':
+                if (/hello/g.test(serverStdoutBuffer)) {
+                    forcedClosed = true;
+                    serverExitCode = 0;
+                    // End the current SSL connection and exit.
+                    // See s_server(1ssl).
+                    
+                    // bug - doesn't always work... seems buffering to exe is happening
+                    var bye= 'Q\n';
+                    server.stdin.write(bye);
+                    server.stdin.end();
+                    state = 'WAIT-SERVER-CLOSE';
+                }
+                break;
+
+            default:
+                break;
+        }
+    });
+
+
+    var timeout = setTimeout(function () {
+        server.kill();
+        if (serverExitCode != 0) {
+            console.log('killed');
+            process.exit(1);
+        }
+        else
+            process.exit(0);
+    }, 5000);
+
+    server.on('exit', function (code) {
+        console.log('server.on.exit');
+        serverExitCode = code;
+        clearTimeout(timeout);
+    });
+
+}
+
+function startClient() {
+    var s = new net.Stream();
+
+    var sslcontext = crypto.createCredentials({});
+    sslcontext.context.setCiphers(PSKCiphers);
+
+    function clientCallback(hint) {
+        assert.equal(sharedHint, hint);
+        if (hint == sharedHint) {
+            return {
+                identity: identity,
+                key: new Buffer(pskey, 'hex')
+            }
+        }
+        return null;
+    }
+
+    var pair = tls.createSecurePair(sslcontext, false, null, null, clientCallback);
+
+    assert.ok(pair.encrypted.writable);
+    assert.ok(pair.cleartext.writable);
+
+    pair.encrypted.pipe(s);
+    s.pipe(pair.encrypted);
+
+    s.connect(PORT);
+
+    s.on('connect', function () {
+        console.log('client connected');
+    });
+
+    pair.once   ('secure', function () {
+        console.log('client: connected+secure!');
+        console.log('client pair.cleartext.getCipher(): %j',
+            pair.cleartext.getCipher());
+        setTimeout(function () {
+            pair.cleartext.write('hello\r\n', function () {
+                gotWriteCallback = true;
+            });
+        }, 500);
+    });
+
+    pair.cleartext.on('data', function (d) {
+        console.log('cleartext: %s', d.toString());
+    });
+
+    s.on('close', function () {
+        console.log('client close');
+    });
+
+    pair.encrypted.on('error', function (err) {
+        console.log('encrypted error: ' + err);
+    });
+
+    s.on('error', function (err) {
+        if (forcedClosed)
+            console.log('closed by server - OK');
+        else 
+            console.log('socket error: ' + err);
+    });
+
+    pair.on('error', function (err) {
+        console.log('secure error: ' + err);
+    });
+}
+
+if (useTestServer){
+  startClient();
+}
+
+process.on('exit', function () {
+    assert.equal(0, serverExitCode);
+    assert.equal('WAIT-SERVER-CLOSE', state);
+    assert.ok(gotWriteCallback);
+});
+

--- a/test/simple/test-tls-psk-server.js
+++ b/test/simple/test-tls-psk-server.js
@@ -1,0 +1,178 @@
+// Copyright & License details are available under JXCORE_LICENSE file
+
+
+if (!process.versions.openssl) {
+  console.error("Skipping because node compiled without OpenSSL.");
+  process.exit(0);
+}
+if (parseInt(process.versions.openssl[0]) < 1) {
+  console.error("Skipping because node compiled with old OpenSSL version.");
+  process.exit(0);
+}
+
+
+var common = require('../common');
+var assert = require('assert');
+
+var join = require('path').join;
+var net = require('net');
+var fs = require('fs');
+var crypto = require('crypto');
+var tls = require('tls');
+var spawn = require('child_process').spawn;
+var exec = require('child_process').exec;
+
+// versions of openssl do not support PSK
+// Therefore we skip this
+// test for all openssl versions less than 1.0.0.
+function checkOpenSSL() {
+  exec('openssl version', function(err, data) {;
+    if (err) throw err;
+    if (/OpenSSL 0\./.test(data)) {
+      console.error('Skipping due to old OpenSSL version.');
+      return false;
+    }
+    else {
+      return true;
+    }
+  });
+}
+
+if (! checkOpenSSL()){
+  console.error("Skipping because OpenSSL version < 1.0.0.");
+  process.exit(0)
+}
+
+
+var connections = 0;
+var pskey = "d731ef57be09e5204f0b205b60627028";
+var identity = 'TestUser';
+
+var PSKCiphers = 'PSK-AES256-CBC-SHA:PSK-3DES-EDE-CBC-SHA:PSK-AES128-CBC-SHA:PSK-RC4-SHA';
+
+function log(a) {
+  console.error('+++ server +++ ' + a);
+}
+
+var server = net.createServer(function(socket) {
+  connections++;
+  var isWin = /^win/.test(process.platform);
+  if (!isWin)  log('connection fd=' + socket.fd);
+  log('connectionKey: ' + socket.server._connectionKey);
+  var sslcontext = crypto.createCredentials({});
+  sslcontext.context.setCiphers(PSKCiphers);
+
+  function serverCallback(id) {
+    if (id == identity) {
+      return new Buffer(pskey, 'hex');
+    }
+    return null;
+  }
+  sslcontext.context.setPskServerCallback(serverCallback);
+
+  var pair = tls.createSecurePair(sslcontext, true);
+
+  assert.ok(pair.encrypted.writable);
+  assert.ok(pair.cleartext.writable);
+
+  pair.encrypted.pipe(socket);
+  socket.pipe(pair.encrypted);
+
+  log('i set it secure');
+
+  pair.on('secure', function() {
+    log('connected+secure!');
+    pair.cleartext.write('hello\r\n');
+    log(pair.cleartext.getPeerCertificate());
+    var cipher = pair.cleartext.getCipher();
+    log('cipher name and version: ' + cipher.name + ':' + cipher.version);
+  });
+
+  pair.cleartext.on('data', function(data) {
+    log('read bytes ' + data.length);
+    pair.cleartext.write(data);
+  });
+
+  socket.on('end', function() {
+    log('socket end');
+  });
+
+  pair.cleartext.on('error', function(err) {
+    log('got error: ');
+    log(err);
+    log(err.stack);
+    socket.destroy();
+  });
+
+  pair.encrypted.on('error', function(err) {
+    log('encrypted error: ');
+    log(err);
+    log(err.stack);
+    socket.destroy();
+  });
+
+  socket.on('error', function(err) {
+    log('socket error: ');
+    log(err);
+    log(err.stack);
+    socket.destroy();
+  });
+
+  socket.on('close', function(err) {
+    log('socket closed');
+  });
+
+  pair.on('error', function(err) {
+    log('secure error: ');
+    log(err);
+    log(err.stack);
+    socket.destroy();
+  });
+});
+
+var gotHello = false;
+var sentWorld = false;
+var gotWorld = false;
+var opensslExitCode = -1;
+
+server.listen(common.PORT, function() {
+  var client = spawn('openssl', ['s_client',
+                                 '-connect', '127.0.0.1:' + common.PORT,
+                                 '-psk', pskey,
+                                 '-cipher', PSKCiphers,
+                                 '-psk_identity', identity]);
+
+  var out = '';
+
+  client.stdout.setEncoding('utf8');
+  client.stdout.on('data', function(d) {
+    out += d;
+
+    if (!gotHello && /hello/.test(out)) {
+      gotHello = true;
+      client.stdin.write('world\r\n');
+      sentWorld = true;
+    }
+
+    if (!gotWorld && /world/.test(out)) {
+      gotWorld = true;
+      client.stdin.end();
+    }
+  });
+
+  client.stdout.pipe(process.stdout, { end: false });
+  client.stderr.pipe(process.stderr, { end: false });
+
+  client.on('exit', function(code) {
+    opensslExitCode = code;
+    server.close();
+  });
+});
+
+process.on('exit', function() {
+  assert.equal(1, connections);
+  assert.ok(gotHello);
+  assert.ok(sentWorld);
+  assert.ok(gotWorld);
+  assert.equal(0, opensslExitCode);
+});


### PR DESCRIPTION
This adds support for Pre-shared-keys using OpenSSL 1.0.x implementation and the currently supported PSK in OpenSSL which are:
```
PSK-AES256-CBC-SHA:PSK-3DES-EDE-CBC-SHA:PSK-AES128-CBC-SHA:
```


**Update: This PR/commit has been updated and corrected all macro usage cross V8/Moz. **

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/jxcore/jxcore/813)
<!-- Reviewable:end -->
