### PR TITLE
jxcore: assign correct value to 'hasStdFds'

### DIFF
--- a/src/jx/commons.cc
+++ b/src/jx/commons.cc
@@ -490,6 +490,7 @@ commons::commons(const int tid) {
     threadPing = NULL;
   } else {
     loop = uv_loop_new();
+    loop->loopId = threadId;
     uv_setThreadLoop(threadId - 1, loop);
 
 #ifndef _MSC_VER

--- a/src/node.cc
+++ b/src/node.cc
@@ -2258,7 +2258,7 @@ void SetupProcessObject(const int threadId, bool debug_worker) {
   // Check if the process has standard stream file descriptors, needed for
   // allocating a normal console object.
   JS_NAME_SET(process, JS_STRING_ID("hasStdFds"),
-              STD_TO_BOOLEAN(uv_guess_handle(1) == UV_UNKNOWN_HANDLE));
+              STD_TO_BOOLEAN(uv_guess_handle(1) != UV_UNKNOWN_HANDLE));
 
   JS_NAME_SET(process, JS_STRING_ID("isPackaged"),
               STD_TO_BOOLEAN(com->is_packaged_));


### PR DESCRIPTION
Fix #608 somehow introduced a broken fix for supporting embedded headless client (like e.g. Windows UI applications). The 'hasStdFds' should indicate whether stdout/stdin/stderr is available, in #608 however it was true when the handle type for stdout was unknown. Adjusting this to do the opposite caused a crash in a sub engine being started on a different thread. This is due to the loopId member variable not being initialized. Assigning 'threadId' to the 'loopId' (like the main thread implicitly does) seems to fix this problem.