### PR TITLE
jxcore: initialize loopId member of (uv) loop

### DIFF
--- a/src/jx/commons.cc
+++ b/src/jx/commons.cc
@@ -491,6 +491,7 @@ commons::commons(const int tid) {
   } else {
     loop = uv_loop_new();
     uv_setThreadLoop(threadId - 1, loop);
+    loop->loopId = threadId;
 
 #ifndef _MSC_VER
     threadPing = new uv_async_t;


### PR DESCRIPTION
for java-script subengines the loopId member was not initialized, this causes a crash when running headless