### PR TITLE
Fixes in the third party libraries for compilation under the ARM64 with Android API level 21.

### DIFF
--- a/deps/cares/src/android_api21.h
+++ b/deps/cares/src/android_api21.h
@@ -1,0 +1,35 @@
+#include <android/log.h>
+#include <dlfcn.h>
+
+/*
+ * http://stackoverflow.com/questions/28413530/api-to-get-android-system-properties-is-removed-in-arm64-platforms
+ *
+ * It's useful API for native apps, just as it is for Java apps, it originates from the native side
+ * (see http://rxwen.blogspot.com/2010/01/android-property-system.html), 
+ * and other Android system code uses it, so it's unlikely to go away soon.
+ */
+
+#if (__ANDROID_API__ >= 21)
+/* 
+ * Android 'L' makes __system_property_get a non-global symbol.
+ * Here we provide a stub which loads the symbol from libc via dlsym.
+ */
+typedef int (*PFN_SYSTEM_PROP_GET)(const char *, char *);
+int __system_property_get(const char* name, char* value)
+{
+    static PFN_SYSTEM_PROP_GET __real_system_property_get = 0;
+    if (!__real_system_property_get) {
+        /* libc.so should already be open, get a handle to it. */
+        void *handle = dlopen("libc.so", RTLD_NOLOAD);
+        if (!handle) {
+            __android_log_print(ANDROID_LOG_ERROR, "foobar", "Cannot dlopen libc.so: %s.\n", dlerror());
+        } else {
+            __real_system_property_get = (PFN_SYSTEM_PROP_GET)dlsym(handle, "__system_property_get");
+        }
+        if (!__real_system_property_get) {
+            __android_log_print(ANDROID_LOG_ERROR, "foobar", "Cannot resolve __system_property_get(): %s.\n", dlerror());
+        }
+    }
+    return (*__real_system_property_get)(name, value);
+} 
+#endif // __ANDROID_API__ >= 21

--- a/deps/cares/src/android_api21.h
+++ b/deps/cares/src/android_api21.h
@@ -1,5 +1,3 @@
-#include <android/log.h>
-#include <dlfcn.h>
 
 /*
  * http://stackoverflow.com/questions/28413530/api-to-get-android-system-properties-is-removed-in-arm64-platforms
@@ -10,6 +8,10 @@
  */
 
 #if (__ANDROID_API__ >= 21)
+
+#include <android/log.h>
+#include <dlfcn.h>
+
 /* 
  * Android 'L' makes __system_property_get a non-global symbol.
  * Here we provide a stub which loads the symbol from libc via dlsym.

--- a/deps/cares/src/ares_init.c
+++ b/deps/cares/src/ares_init.c
@@ -15,6 +15,8 @@
  * without express or implied warranty.
  */
 
+#include "android_api21.h"
+
 #include "ares_setup.h"
 
 #ifdef HAVE_SYS_PARAM_H

--- a/deps/uv/src/unix/thread.c
+++ b/deps/uv/src/unix/thread.c
@@ -237,7 +237,7 @@ int uv_cond_init(uv_cond_t* cond) {
 
   if (pthread_condattr_init(&attr)) return -1;
 
-#if !defined(__ANDROID__)
+#if !(defined(__ANDROID__) && defined(HAVE_PTHREAD_COND_TIMEDWAIT_MONOTONIC))
   if (pthread_condattr_setclock(&attr, CLOCK_MONOTONIC)) goto error2;
 #endif
 
@@ -284,7 +284,7 @@ int uv_cond_timedwait(uv_cond_t* cond, uv_mutex_t* mutex, uint64_t timeout) {
   timeout += uv__hrtime();
   ts.tv_sec = timeout / NANOSEC;
   ts.tv_nsec = timeout % NANOSEC;
-#if defined(__ANDROID__)
+#if defined(__ANDROID__) && defined(HAVE_PTHREAD_COND_TIMEDWAIT_MONOTONIC)
   r = pthread_cond_timedwait_monotonic_np(cond, mutex, &ts);
 #else
   r = pthread_cond_timedwait(cond, mutex, &ts);


### PR DESCRIPTION
1. In API level 21 the function pthread_cond_timedwait_monotonic_np was removed from 64-bit paltforms.
For more details see [Android 5.0 does not have pthread_cond_timedwait_monotonic_np](libuv/libuv#172)

2. __system_property_get() is defined in libc.so but it is hidden in the 64-bit Android NDK toolchains
For more information see [__system_property_get() is not a public API](http://stackoverflow.com/questions/28413530/api-to-get-android-system-properties-is-removed-in-arm64-platforms)