### PR TITLE
Add --static-library option for vcbuild.bat

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -127,9 +127,6 @@
             ],
           },
           'VCLibrarianTool': {
-            'AdditionalOptions': [
-              '/LTCG', # link time code generation
-            ],
           },
           'VCLinkerTool': {
             'LinkTimeCodeGeneration': 1, # link-time code generation
@@ -151,6 +148,9 @@
         'WarnAsError': 'false',
       },
       'VCLibrarianTool': {
+        'AdditionalOptions': [
+          '/LTCG', # link time code generation
+        ],
       },
       'VCLinkerTool': {
         'conditions': [

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -72,6 +72,7 @@ if /i "%1"=="msi"           set msi=1&set licensertf=1&goto arg-ok
 if /i "%1"=="upload"        set upload=1&goto arg-ok
 if /i "%1"=="jslint"        set jslint=1&goto arg-ok
 if /i "%1"=="--win-onecore" set wincore=--win-onecore&set no_asm=--openssl-no-asm&set leveldown=--embed-leveldown&goto arg-ok
+if /i "%1"=="--static-library" set static_library=--static-library&goto arg-ok
 if /i "%1"=="--shared-library" set static_library=--shared-library&goto arg-ok
 if /i "%1"=="--engine-mozilla" set engine_=--engine-mozilla&goto arg-ok
 if /i "%1"=="--engine-chakra" set engine_=--engine-chakra&set WindowsTargetPlatformVersion=10.0.10586.0&goto arg-ok


### PR DESCRIPTION
Same as #840
- Add --static-library option for vcbuild.bat
- Fix LNK1241 error on building static debug library with MSVC
