### PR TITLE
configure: Fix shebang for systems defaulting to python3

### DIFF
--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import optparse
 import os
 import pprint


### PR DESCRIPTION
There is a significant fraction of systems running with python symlinked to python3. To aid portability to these systems, use explicit python2 instead of generic python in python2-only configure script.