### PR TITLE
Update toolchain and utf8 for psk identity

### DIFF
--- a/build_scripts/android-configure.sh
+++ b/build_scripts/android-configure.sh
@@ -41,7 +41,7 @@ export TOOLCHAIN_INTEL=$PWD/android-toolchain-intel
 rm -rf $TOOLCHAIN_INTEL
 mkdir -p $TOOLCHAIN_INTEL
 $1/build/tools/make-standalone-toolchain.sh \
-    --toolchain=x86-4.8 \
+    --toolchain=x86-4.9 \
     --arch=x86 \
     --install-dir=$TOOLCHAIN_INTEL \
     --platform=$ANDROID_TARGET

--- a/src/wrappers/node_crypto.cc
+++ b/src/wrappers/node_crypto.cc
@@ -2073,8 +2073,8 @@ unsigned int node::crypto::
 
     if (JS_IS_STRING(id) && Buffer::HasInstance(key)) {
       // write the chosen client identity string into the buffer provided
-      ssize_t hlen = StringBytes::JXSize(id, ASCII, false);
-      StringBytes::JXWrite(identity, hlen, id, ASCII, false);
+      ssize_t hlen = StringBytes::JXSize(id, UTF8, false);
+      StringBytes::JXWrite(identity, hlen, id, UTF8, false);
 
       // write the id's binary key into the buffer provided
       JS_LOCAL_OBJECT(keyBuffer) = JS_VALUE_TO_OBJECT(key);


### PR DESCRIPTION
Hi,
these are two commits from thaliproject/jxcore:
 - Update toolchain for building ndk version
 - Using utf8 instead of ascii for psk identity
Thank you.