### PR TITLE
build for mobile without compress_internals

### DIFF
--- a/build_scripts/android_compile.sh
+++ b/build_scripts/android_compile.sh
@@ -18,7 +18,7 @@ ERROR_ABORT() {
   if [[ $? != 0 ]]
   then
     LOG $RED_COLOR "compilation aborted\n"
-    exit  
+    exit
   fi
 }
 
@@ -28,7 +28,7 @@ ERROR_ABORT_MOVE() {
   then
     $($1)
     LOG $RED_COLOR "compilation aborted for $2 target\n"
-    exit  
+    exit
   fi
 }
 
@@ -54,52 +54,52 @@ ARM7=out_arm_droid
 INTEL64=out_x64_droid
 INTEL32=out_ia32_droid
 FATBIN=out_android/android
-    
+
 MAKE_INSTALL() {
   TARGET_DIR="out_$1_droid"
   mv $TARGET_DIR out
-  ./configure --static-library --dest-os=android --dest-cpu=$1 --engine-mozilla --compress-internals $CONF_EXTRAS
+  ./configure --static-library --dest-os=android --dest-cpu=$1 --engine-mozilla $CONF_EXTRAS
   ERROR_ABORT_MOVE "mv out $TARGET_DIR" $1
   make -j 2
   ERROR_ABORT_MOVE "mv out $TARGET_DIR" $1
-  
+
   PREFIX_DIR="out/Release"
   $STRIP -d $PREFIX_DIR/libcares.a
   mv $PREFIX_DIR/libcares.a "$PREFIX_DIR/libcares_$1.a"
-  
+
   $STRIP -d $PREFIX_DIR/libchrome_zlib.a
   mv $PREFIX_DIR/libchrome_zlib.a "$PREFIX_DIR/libchrome_zlib_$1.a"
-  
+
   $STRIP -d $PREFIX_DIR/libhttp_parser.a
   mv $PREFIX_DIR/libhttp_parser.a "$PREFIX_DIR/libhttp_parser_$1.a"
-  
+
   $STRIP -d $PREFIX_DIR/libjx.a
   mv $PREFIX_DIR/libjx.a "$PREFIX_DIR/libjx_$1.a"
-  
+
   $STRIP -d $PREFIX_DIR/libmozjs.a
   mv $PREFIX_DIR/libmozjs.a "$PREFIX_DIR/libmozjs_$1.a"
-  
+
   $STRIP -d $PREFIX_DIR/libopenssl.a
   mv $PREFIX_DIR/libopenssl.a "$PREFIX_DIR/libopenssl_$1.a"
-  
+
   $STRIP -d $PREFIX_DIR/libuv.a
   mv $PREFIX_DIR/libuv.a "$PREFIX_DIR/libuv_$1.a"
-  
+
   $STRIP -d $PREFIX_DIR/libsqlite3.a
   mv $PREFIX_DIR/libsqlite3.a "$PREFIX_DIR/libsqlite3_$1.a"
-  
+
 if [ "$CONF_EXTRAS" == "--embed-leveldown" ]
 then
   $STRIP -d $PREFIX_DIR/libleveldown.a
   mv $PREFIX_DIR/libleveldown.a "$PREFIX_DIR/libleveldown_$1.a"
-  
+
   $STRIP -d $PREFIX_DIR/libsnappy.a
   mv $PREFIX_DIR/libsnappy.a "$PREFIX_DIR/libsnappy_$1.a"
-  
+
   $STRIP -d $PREFIX_DIR/libleveldb.a
   mv $PREFIX_DIR/libleveldb.a "$PREFIX_DIR/libleveldb_$1.a"
 fi
-  
+
   mv out $TARGET_DIR
 }
 

--- a/build_scripts/ios_compile.sh
+++ b/build_scripts/ios_compile.sh
@@ -25,7 +25,7 @@ ERROR_ABORT() {
   if [[ $? != 0 ]]
   then
     LOG $RED_COLOR "compilation aborted\n"
-    exit	
+    exit
   fi
 }
 
@@ -35,7 +35,7 @@ ERROR_ABORT_MOVE() {
   then
     $($1)
     LOG $RED_COLOR "compilation aborted for $2 target\n"
-	exit	
+	exit
   fi
 }
 
@@ -63,13 +63,13 @@ MAKE_INSTALL() {
   TARGET_DIR="out_$1_ios"
   PREFIX_DIR="out_ios/$1"
   mv $TARGET_DIR out
-  ./configure --prefix=$PREFIX_DIR --static-library --dest-os=ios --dest-cpu=$1 --engine-mozilla --compress-internals $CONF_EXTRAS
+  ./configure --prefix=$PREFIX_DIR --static-library --dest-os=ios --dest-cpu=$1 --engine-mozilla $CONF_EXTRAS
   ERROR_ABORT_MOVE "mv out $TARGET_DIR" $1
   rm -rf $PREFIX_DIR/bin
   make -j 2 install
   ERROR_ABORT_MOVE "mv out $TARGET_DIR" $1
   mv out $TARGET_DIR
-	
+
   mv $PREFIX_DIR/bin/libcares.a "$PREFIX_DIR/bin/libcares_$1.a"
   mv $PREFIX_DIR/bin/libchrome_zlib.a "$PREFIX_DIR/bin/libchrome_zlib_$1.a"
   mv $PREFIX_DIR/bin/libhttp_parser.a "$PREFIX_DIR/bin/libhttp_parser_$1.a"
@@ -78,7 +78,7 @@ MAKE_INSTALL() {
   mv $PREFIX_DIR/bin/libopenssl.a "$PREFIX_DIR/bin/libopenssl_$1.a"
   mv $PREFIX_DIR/bin/libuv.a "$PREFIX_DIR/bin/libuv_$1.a"
   mv $PREFIX_DIR/bin/libsqlite3.a "$PREFIX_DIR/bin/libsqlite3_$1.a"
-  
+
   if [ "$CONF_EXTRAS" == "--embed-leveldown" ]
   then
     mv $TARGET_DIR/Release/libleveldown.a "$PREFIX_DIR/bin/libleveldown_$1.a"
@@ -98,7 +98,7 @@ MAKE_FAT() {
     strip -x "$INTEL64/bin/$1_x64.a"
     strip -x "$INTEL32/bin/$1_ia32.a"
   fi
-  
+
   lipo -create "$ARM64/bin/$1_arm64.a" "$ARM7/bin/$1_arm.a" "$ARM7s/bin/$1_armv7s.a" "$INTEL64/bin/$1_x64.a" "$INTEL32/bin/$1_ia32.a" -output "$FATBIN/bin/$1.a"
   ERROR_ABORT
 }
@@ -127,7 +127,7 @@ MAKE_INSTALL arm64
 
 LOG $GREEN_COLOR "Compiling IOS INTEL64\n"
 MAKE_INSTALL x64
- 
+
 
 LOG $GREEN_COLOR "Preparing FAT binaries\n"
 rm -rf $FATBIN


### PR DESCRIPTION
jx may not be available on target machine + no installer support. So remove compress_internals requirements