### PR TITLE
Fixed leveldown-mobile failing to install on Windows.

### DIFF
--- a/deps/npm/node_modules/node-gyp/addon.gypi
+++ b/deps/npm/node_modules/node-gyp/addon.gypi
@@ -40,7 +40,7 @@
         'conditions': [
           [ 'OS=="win"', {
             'sources': [
-              '<(node_gyp_dir)/src/win_delay_load_hook.c',
+              '<(node_gyp_dir)/src/win_delay_load_hook.cc',
             ],
             'msvs_settings': {
               'VCLinkerTool': {

--- a/deps/npm/node_modules/node-gyp/src/win_delay_load_hook.cc
+++ b/deps/npm/node_modules/node-gyp/src/win_delay_load_hook.cc
@@ -9,7 +9,10 @@
 
 #ifdef _MSC_VER
 
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
+
 #include <windows.h>
 
 #include <delayimp.h>
@@ -28,6 +31,6 @@ static FARPROC WINAPI load_exe_hook(unsigned int event, DelayLoadInfo* info) {
   return (FARPROC) m;
 }
 
-PfnDliHook __pfnDliNotifyHook2 = load_exe_hook;
+decltype(__pfnDliNotifyHook2) __pfnDliNotifyHook2 = load_exe_hook;
 
 #endif


### PR DESCRIPTION
This fixes: [leveldown mobile failing to install on Windows](https://github.com/thaliproject/Thali_CordovaPlugin/issues/763).

The node-gyp version that comes with npm 3.3.12 is incompatible with Visual Studio 2015.
The fix is the same fix applied for npm 3.4.0:
https://github.com/nodejs/node-gyp/commit/f31482e2260e3beb90d959c62135e5e95c06ed4d

In order to have this fix available after merging it, npmjx311.tar.gz needs to be recreated using deps/packnpm.sh.

Be aware that on a clean machine packnpm.sh produces a npmjx311.tar.gz file that may be different from the current version available online, it will miss the 'debug' sub-module for:
npm/node_modules/node-gyp/node_modules/path-array/node_modules/array-index
that will causing an error when installing the leveldown-mobile module.
I've submitted another PR to add the missing 'debug' module.
