### PR TITLE
Fix for Android release builds.

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -451,6 +451,13 @@
           if (process._MTED) {
             process.argv[2] = path.resolve(process.argv[2]);
           } else {
+            // Fix for Android release builds
+            if (!process.cwd()) {
+              process.cwd = function() {
+                return "/system/bin/";
+              }
+            }
+            // Fix end
             process.argv[1] = path.resolve(process.argv[1]);
           }
 


### PR DESCRIPTION
This fixes: [App fails to load on some devices to error "No such native module"](https://github.com/thaliproject/Thali_CordovaPlugin/issues/594).
