### PR TITLE
Log skipped tests.

### DIFF
--- a/test/simple/path.js
+++ b/test/simple/path.js
@@ -1,14 +1,11 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
-
-
-
 // This is actually more a fixture than a test. It is used to make
-var common = require('../common');
 // sure that require('./path') and require('path') do different things.
 // It has to be in the same directory as the test 'test-module-loading.js'
 // and it has to have the same name as an internal module.
+var common = require('../common');
+
 exports.path_func = function() {
   return 'path_func';
 };

--- a/test/simple/test-abort-fatal-error.js
+++ b/test/simple/test-abort-fatal-error.js
@@ -1,16 +1,22 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
+if (process.platform === 'win32') {
+  console.error('Skipping: platform is Windows.');
+  process.exit(0);
+}
 
-if (process.versions.sm) { return; }
-if (process.versions.v8 && parseFloat(process.versions.v8) > 3.15) { return; }
+if (process.versions.sm) {
+    console.error('Skipping: engine is SpiderMonkey.');
+    process.exit(0);
+}
+
+if (process.versions.v8 && parseFloat(process.versions.v8) > 3.15) {
+    console.error('Skipping: engine V8 > 3.15.');
+    process.exit(0);
+}
 
 var assert = require('assert');
 var common = require('../common');
-
-if (process.platform === 'win32') {
-  console.log('skipping test on windows');
-  process.exit(0);
-}
 
 var exec = require('child_process').exec;
 

--- a/test/simple/test-api-tasks.js
+++ b/test/simple/test-api-tasks.js
@@ -1,8 +1,10 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
 // disable this test on travis [timeouts etc]
-if (process.cwd().indexOf('travis/')>0)
-  return;
+if (process.cwd().indexOf('travis/')>0) {
+  console.error('Skipping: running on Travis.');
+  process.exit(0);
+}
 
 var reset = true;
 var counter = 0;

--- a/test/simple/test-arraybuffer-slice.js
+++ b/test/simple/test-arraybuffer-slice.js
@@ -8,8 +8,15 @@
 // Chakra, SpiderMonkey && v8 3.15+ implementation has native TypedArray support
 
 var ver = process.versions;
-if (ver.sm || ver.ch) return;
-if (parseFloat(ver.v8)>3.14) return;
+if (ver.sm || ver.ch) {
+  console.error('Skipping: SpiderMonkey and Chakra have native TypedArray support.');
+  process.exit(0);
+}
+
+if (parseFloat(ver.v8) > 3.14) {
+  console.error('Skipping: V8 > 3.14 has native TypedArray support.');
+  process.exit(0);
+}
 
 var common = require('../common');
 var assert = require('assert');

--- a/test/simple/test-c-ares.js
+++ b/test/simple/test-c-ares.js
@@ -1,11 +1,9 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 var common = require('../common');
 var assert = require('assert');
 
 var dns = require('dns');
-
 
 // Try resolution without callback
 
@@ -37,4 +35,6 @@ if (process.platform != 'win32') {
     if (error) throw error;
     assert.ok(Array.isArray(domains));
   });
+} else {
+  console.error('Skipping: test-step skipped because platform is Windows.');
 }

--- a/test/simple/test-child-process-double-pipe.js
+++ b/test/simple/test-child-process-double-pipe.js
@@ -1,9 +1,12 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
+if (process.platform === 'win32') {
+  console.error('Skipping: platform is Windows.');
+  process.exit(0);
+}
 
 var is_windows = process.platform === 'win32';
 
-if(!is_windows){
 var common = require('../common');
 var assert = require('assert'),
     util = require('util'),
@@ -34,8 +37,6 @@ if (is_windows) {
  * explained above.
  */
 
-
-
 // pipe echo | grep
 echo.stdout.on('data', function(data) {
   console.error('grep stdin write ' + data.length);
@@ -65,8 +66,6 @@ sed.on('exit', function() {
   console.error('sed exit');
 });
 
-
-
 // pipe grep | sed
 grep.stdout.on('data', function(data) {
   console.error('grep stdout ' + data.length);
@@ -85,8 +84,6 @@ grep.stdout.on('end', function(code) {
   sed.stdin.end();
 });
 
-
-
 var result = '';
 
 // print sed's output
@@ -98,4 +95,3 @@ sed.stdout.on('data', function(data) {
 sed.stdout.on('end', function(code) {
   assert.equal(result, 'hellO\nnOde\nwOrld\n');
 });
-}

--- a/test/simple/test-child-process-fork-dgram.js
+++ b/test/simple/test-child-process-fork-dgram.js
@@ -1,15 +1,14 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
+if (process.platform === 'win32') {
+  console.error('Skipping: dgram sockets to child processes not supported on Windows.');
+  process.exit(0);
+}
 
 var dgram = require('dgram');
 var fork = require('child_process').fork;
 var assert = require('assert');
 var common = require('../common');
-
-if (process.platform === 'win32') {
-  console.error('Sending dgram sockets to child processes not supported');
-  process.exit(0);
-}
 
 if (process.argv[2] === 'child') {
   var childCollected = 0;

--- a/test/simple/test-cluster-bind-twice-v2.js
+++ b/test/simple/test-cluster-bind-twice-v2.js
@@ -1,5 +1,9 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
+if (process.platform === 'win32') {
+  console.error('Skipping: platform is Windows.');
+  process.exit(0);
+}
 
 // This test starts two clustered HTTP servers on the same port. It expects the
 // first cluster to succeed and the second cluster to fail with EADDRINUSE.
@@ -20,9 +24,6 @@
 //
 // See https://github.com/joyent/node/issues/2721 for more details.
 
-var is_windows = process.platform === 'win32';
-
-if(!is_windows){
 var common = require('../common');
 var assert = require('assert');
 var cluster = require('cluster');
@@ -109,5 +110,3 @@ else if (id === 'two') {
 else {
   assert(0); // bad command line argument
 }
-
-} // !is_windows

--- a/test/simple/test-cluster-dgram-1.js
+++ b/test/simple/test-cluster-dgram-1.js
@@ -1,5 +1,9 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
+if (process.platform === 'win32') {
+  console.error('Skipping: dgram clustering is currently not supported on Windows.');
+  process.exit(0);
+}
 
 var NUM_WORKERS = 4;
 var PACKETS_PER_WORKER = 10;
@@ -9,17 +13,10 @@ var cluster = require('cluster');
 var common = require('../common');
 var dgram = require('dgram');
 
-
-if (process.platform === 'win32') {
-  console.warn("dgram clustering is currently not supported on windows.");
-  process.exit(0);
-}
-
 if (cluster.isMaster)
   master();
 else
   worker();
-
 
 function master() {
   var listening = 0;
@@ -75,7 +72,6 @@ function master() {
     });
   }
 }
-
 
 function worker() {
   var received = 0;

--- a/test/simple/test-cluster-dgram-2.js
+++ b/test/simple/test-cluster-dgram-2.js
@@ -1,5 +1,9 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
+if (process.platform === 'win32') {
+  console.error('Skipping: dgram clustering is currently not supported on Windows.');
+  process.exit(0);
+}
 
 var NUM_WORKERS = 4;
 var PACKETS_PER_WORKER = 10;
@@ -9,17 +13,10 @@ var cluster = require('cluster');
 var common = require('../common');
 var dgram = require('dgram');
 
-
-if (process.platform === 'win32') {
-  console.warn("dgram clustering is currently not supported on windows.");
-  process.exit(0);
-}
-
 if (cluster.isMaster)
   master();
 else
   worker();
-
 
 function master() {
   var i;
@@ -49,7 +46,6 @@ function master() {
   for (var i = 0; i < NUM_WORKERS; i++)
     cluster.fork();
 }
-
 
 function worker() {
   // Create udp socket and send packets to master.

--- a/test/simple/test-cluster-http-pipe.js
+++ b/test/simple/test-cluster-http-pipe.js
@@ -1,8 +1,8 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 // It is not possible to send pipe handles over the IPC pipe on Windows.
 if (process.platform === 'win32') {
+  console.error("Skipping: can't send pipe handles over the IPC pipe on Windows.");
   process.exit(0);
 }
 

--- a/test/simple/test-crypto-binary-default.js
+++ b/test/simple/test-crypto-binary-default.js
@@ -1,19 +1,22 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
+// this test file is not compatible to Windows
+if (process.platform === 'win32') {
+  console.error('Skipping: platform is Windows.');
+  process.exit(0);
+}
+
 // This is the same as test/simple/test-crypto, but from before the shift
 // to use buffers by default.
 
 var common = require('../common');
 var assert = require('assert');
 
-// this test file is not compatible to Windows
-if (process.platform === 'win32') return;
-
 try {
   var crypto = require('crypto');
 } catch (e) {
-  console.log('Not compiled with OPENSSL support.');
-  process.exit();
+  console.error('Skipping: Not compiled with OPENSSL support.');
+  process.exit(0);
 }
 
 crypto.DEFAULT_ENCODING = 'binary';
@@ -37,8 +40,8 @@ try {
                                                cert: certPem,
                                                ca: caPem});
 } catch (e) {
-  console.log('Not compiled with OPENSSL support.');
-  process.exit();
+  console.error('Skipping: Not compiled with OPENSSL support.');
+  process.exit(0);
 }
 
 // PFX tests

--- a/test/simple/test-crypto-ecb.js
+++ b/test/simple/test-crypto-ecb.js
@@ -1,17 +1,13 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
-
-
-
 var common = require('../common');
 var assert = require('assert');
 
 try {
   var crypto = require('crypto');
 } catch (e) {
-  console.log('Not compiled with OPENSSL support.');
-  process.exit();
+  console.error('Skipping: Not compiled with OPENSSL support.');
+  process.exit(0);
 }
 
 crypto.DEFAULT_ENCODING = 'buffer';

--- a/test/simple/test-crypto-padding-aes256.js
+++ b/test/simple/test-crypto-padding-aes256.js
@@ -1,14 +1,13 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 var common = require('../common');
 var assert = require('assert');
 
 try {
   var crypto = require('crypto');
 } catch (e) {
-  console.log('Not compiled with OpenSSL support.');
-  process.exit();
+  console.error('Skipping: Not compiled with OpenSSL support.');
+  process.exit(0);
 }
 
 crypto.DEFAULT_ENCODING = 'buffer';

--- a/test/simple/test-crypto-padding.js
+++ b/test/simple/test-crypto-padding.js
@@ -1,14 +1,13 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 var common = require('../common');
 var assert = require('assert');
 
 try {
   var crypto = require('crypto');
 } catch (e) {
-  console.log('Not compiled with OPENSSL support.');
-  process.exit();
+  console.error('Skipping: Not compiled with OpenSSL support.');
+  process.exit(0);
 }
 
 crypto.DEFAULT_ENCODING = 'buffer';

--- a/test/simple/test-crypto-random.js
+++ b/test/simple/test-crypto-random.js
@@ -1,14 +1,13 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 var common = require('../common');
 var assert = require('assert');
 
 try {
   var crypto = require('crypto');
 } catch (e) {
-  console.log('Not compiled with OPENSSL support.');
-  process.exit();
+  console.error('Skipping: Not compiled with OpenSSL support.');
+  process.exit(0);
 }
 
 crypto.DEFAULT_ENCODING = 'buffer';

--- a/test/simple/test-crypto-stream.js
+++ b/test/simple/test-crypto-stream.js
@@ -1,6 +1,5 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 var common = require('../common');
 var assert = require('assert');
 var stream = require('stream');
@@ -9,8 +8,8 @@ var util = require('util');
 try {
   var crypto = require('crypto');
 } catch (e) {
-  console.log('Not compiled with OPENSSL support.');
-  process.exit();
+  console.error('Skipping: Not compiled with OpenSSL support.');
+  process.exit(0);
 }
 
 // Small stream to buffer converter

--- a/test/simple/test-crypto-verify-failure.js
+++ b/test/simple/test-crypto-verify-failure.js
@@ -1,8 +1,7 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
-
-return;
+console.error('Skipping: not supported on any platform.');
+process.exit(0);
 
 var common = require('../common');
 var assert = require('assert');
@@ -11,8 +10,8 @@ try {
   var crypto = require('crypto');
   var tls = require('tls');
 } catch (e) {
-  console.log('Not compiled with OPENSSL support.');
-  process.exit();
+  console.error('Skipping: Not compiled with OpenSSL support.');
+  process.exit(0);
 }
 
 crypto.DEFAULT_ENCODING = 'buffer';

--- a/test/simple/test-crypto.js
+++ b/test/simple/test-crypto.js
@@ -1,17 +1,20 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
+// this test file is not compatible to Windows
+if (process.platform === 'win32') {
+  console.error('Skipping: platform is Windows.');
+  process.exit(0);
+}
+
 var common = require('../common');
 var assert = require('assert');
 var constants = require('constants');
 
-// this test file is not compatible to Windows
-if (process.platform === 'win32') return;
-
 try {
   var crypto = require('crypto');
 } catch (e) {
-  console.log('Not compiled with OPENSSL support.');
-  process.exit();
+  console.error('Skipping: Not compiled with OpenSSL support.');
+  process.exit(0);
 }
 
 crypto.DEFAULT_ENCODING = 'buffer';

--- a/test/simple/test-debug-brk-no-arg.js
+++ b/test/simple/test-debug-brk-no-arg.js
@@ -1,11 +1,12 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
+console.error('Skipping: not supported on any platform.');
+process.exit(0);
 
 var common = require('../common');
 var assert = require('assert');
 var spawn = require('child_process').spawn;
 
-return; 
 var child = spawn(process.execPath, ['--debug-brk=' + common.PORT]);
 child.stderr.once('data', function(c) {
   console.error('%j', c.toString());

--- a/test/simple/test-debugger-client.js
+++ b/test/simple/test-debugger-client.js
@@ -1,8 +1,7 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
-
-return;
+console.error('Skipping: not supported on any platform.');
+process.exit(0);
 
 process.env.NODE_DEBUGGER_TIMEOUT = 2000;
 var common = require('../common');

--- a/test/simple/test-debugger-repl-break-in-module.js
+++ b/test/simple/test-debugger-repl-break-in-module.js
@@ -1,7 +1,7 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
-return;
+console.error('Skipping: not supported on any platform.');
+process.exit(0);
 
 var repl = require('./helper-debugger-repl.js');
 

--- a/test/simple/test-debugger-repl-restart.js
+++ b/test/simple/test-debugger-repl-restart.js
@@ -1,7 +1,8 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
+console.error('Skipping: not supported on any platform.');
+process.exit(0);
 
-return;
 var repl = require('./helper-debugger-repl.js');
 
 repl.startDebugger('breakpoints.js');

--- a/test/simple/test-debugger-repl-utf8.js
+++ b/test/simple/test-debugger-repl-utf8.js
@@ -1,7 +1,7 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
-return;
+console.error('Skipping: not supported on any platform.');
+process.exit(0);
 
 var common = require('../common');
 var script = common.fixturesDir + '/breakpoints_utf8.js';

--- a/test/simple/test-debugger-repl.js
+++ b/test/simple/test-debugger-repl.js
@@ -1,7 +1,8 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
+console.error('Skipping: not supported on any platform.');
+process.exit(0);
 
-return;
 var repl = require('./helper-debugger-repl.js');
 
 repl.startDebugger('breakpoints.js');

--- a/test/simple/test-dgram-broadcast-multi-process.js
+++ b/test/simple/test-dgram-broadcast-multi-process.js
@@ -1,8 +1,8 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
 if (process.env.CITEST) {
-  console.error('Skipping test due to CITEST environmental variable.');
-  process.exit();
+  console.error('Skipping: due to CITEST environmental variable.');
+  process.exit(0);
 }
 
 var common = require('../common'),

--- a/test/simple/test-dh-padding.js
+++ b/test/simple/test-dh-padding.js
@@ -1,14 +1,13 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 var common = require('../common');
 var assert = require('assert');
 
 try {
   var crypto = require('crypto');
 } catch (e) {
-  console.log('Not compiled with OPENSSL support.');
-  process.exit();
+  console.error('Skipping: Not compiled with OpenSSL support.');
+  process.exit(0);
 }
 
 var prime = 'c51f7bf8f0e1cf899243cdf408b1bc7c09c010e33ef7f3fbe5bd5feaf906113b';

--- a/test/simple/test-domain-crypto.js
+++ b/test/simple/test-domain-crypto.js
@@ -1,11 +1,10 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 try {
   var crypto = require('crypto');
 } catch (e) {
-  console.log('Not compiled with OPENSSL support.');
-  process.exit();
+  console.error('Skipping: Not compiled with OpenSSL support.');
+  process.exit(0);
 }
 
 // the missing var keyword is intentional

--- a/test/simple/test-event-emitter-memory-leak.js
+++ b/test/simple/test-event-emitter-memory-leak.js
@@ -1,11 +1,13 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 // Flags: --expose-gc
 
 // gc() does not kick in as it was before
 // so skip it for v8 3.2+
-if (process.versions.ch || parseFloat(process.versions.v8) > 3.2) return;
+if (process.versions.ch || parseFloat(process.versions.v8) > 3.2) {
+  console.error('Skipping: engine is chakra or V8 > 3.2.');
+  process.exit(0);
+}
 
 // Add and remove a lot of different events to an EventEmitter, then check
 // that we didn't leak the event names.

--- a/test/simple/test-file-write-stream.js
+++ b/test/simple/test-file-write-stream.js
@@ -1,6 +1,5 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 var common = require('../common');
 var assert = require('assert');
 
@@ -26,8 +25,8 @@ file
       assert.equal('number', typeof fd);
     })
   .on('error', function(err) {
-      throw err;
       console.error('error!', err.stack);
+      throw err;
     })
   .on('drain', function() {
       console.error('drain!', callbacks.drain);

--- a/test/simple/test-fs-readfile-pipe.js
+++ b/test/simple/test-fs-readfile-pipe.js
@@ -1,16 +1,15 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
+// TODO: Have some way to make this work on windows.
+if (process.platform === 'win32') {
+  console.error('Skipping: no /dev/stdin on Windows.');
+  process.exit(0);
+}
 
 var common = require('../common');
 var assert = require('assert');
 
 // simulate `cat readfile.js | node readfile.js`
-
-// TODO: Have some way to make this work on windows.
-if (process.platform === 'win32') {
-  console.error('No /dev/stdin on windows.  Skipping test.');
-  process.exit();
-}
 
 var fs = require('fs');
 

--- a/test/simple/test-http-304.js
+++ b/test/simple/test-http-304.js
@@ -1,10 +1,9 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
-
-var is_windows = process.platform === 'win32';
-
-if(!is_windows){
+if (process.platform === 'win32') {
+  console.error('Skipping: platform is Windows.');
+  process.exit(0);
+}
 
 var common = require('../common');
 var assert = require('assert');
@@ -28,4 +27,3 @@ s.listen(common.PORT, function() {
 });
 
 console.log('Server running at http://127.0.0.1:' + common.PORT + '/');
-}

--- a/test/simple/test-http-curl-chunk-problem.js
+++ b/test/simple/test-http-curl-chunk-problem.js
@@ -1,68 +1,74 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-var unsupported = jxcore.utils.OSInfo().isMobile || jxcore.utils.OSInfo().isWindows;
-
-if(!unsupported){
-  if (!process.versions.openssl) {
-    console.error('Skipping because node compiled without OpenSSL.');
-    process.exit(0);
-  }
-
-  // http://groups.google.com/group/nodejs/browse_thread/thread/f66cd3c960406919
-  var common = require('../common');
-  var assert = require('assert');
-  var http = require('http');
-  var cp = require('child_process');
-  var fs = require('fs');
-
-  var filename = require('path').join(common.tmpDir, 'big');
-
-  var count = 0;
-  function maybeMakeRequest() {
-    if (++count < 2) return;
-    console.log('making curl request');
-    var cmd = 'curl http://127.0.0.1:' + common.PORT + '/ | openssl sha1';
-    cp.exec(cmd, function(err, stdout, stderr) {
-      if (err) throw err;
-      var hex = stdout.match(/([A-Fa-f0-9]{40})/)[0];
-      assert.equal('8c206a1a87599f532ce68675536f0b1546900d7a', hex);
-      console.log('got the correct response');
-      fs.unlink(filename);
-      server.close();
-    });
-  }
-
-  var ddcmd = common.ddCommand(filename, 10240);
-  console.log('dd command: ', ddcmd);
-
-  cp.exec(ddcmd, function(err, stdout, stderr) {
-    if (err) throw err;
-    maybeMakeRequest();
-  });
-
-  var server = http.createServer(function(req, res) {
-    res.writeHead(200);
-
-    // Create the subprocess
-    var cat = cp.spawn('cat', [filename]);
-
-    // Stream the data through to the response as binary chunks
-    cat.stdout.on('data', function(data) {
-      res.write(data);
-    });
-
-    // End the response on exit (and log errors)
-    cat.on('exit', function(code) {
-      if (code !== 0) {
-        console.error('subprocess exited with code ' + code);
-        exit(1);
-      }
-      res.end();
-    });
-
-  });
-
-  server.listen(common.PORT, maybeMakeRequest);
-
-  console.log('Server running at http://localhost:8080');
+if (jxcore.utils.OSInfo().isMobile) {
+  console.error('Skipping: platform is Mobile.');
+  process.exit(0);
 }
+
+if (jxcore.utils.OSInfo().isWindows) {
+  console.error('Skipping: platform is Windows.');
+  process.exit(0);
+}
+
+if (!process.versions.openssl) {
+  console.error('Skipping: node compiled without OpenSSL.');
+  process.exit(0);
+}
+
+// http://groups.google.com/group/nodejs/browse_thread/thread/f66cd3c960406919
+var common = require('../common');
+var assert = require('assert');
+var http = require('http');
+var cp = require('child_process');
+var fs = require('fs');
+
+var filename = require('path').join(common.tmpDir, 'big');
+
+var count = 0;
+function maybeMakeRequest() {
+  if (++count < 2) return;
+  console.log('making curl request');
+  var cmd = 'curl http://127.0.0.1:' + common.PORT + '/ | openssl sha1';
+  cp.exec(cmd, function(err, stdout, stderr) {
+    if (err) throw err;
+    var hex = stdout.match(/([A-Fa-f0-9]{40})/)[0];
+    assert.equal('8c206a1a87599f532ce68675536f0b1546900d7a', hex);
+    console.log('got the correct response');
+    fs.unlink(filename);
+    server.close();
+  });
+}
+
+var ddcmd = common.ddCommand(filename, 10240);
+console.log('dd command: ', ddcmd);
+
+cp.exec(ddcmd, function(err, stdout, stderr) {
+  if (err) throw err;
+  maybeMakeRequest();
+});
+
+var server = http.createServer(function(req, res) {
+  res.writeHead(200);
+
+  // Create the subprocess
+  var cat = cp.spawn('cat', [filename]);
+
+  // Stream the data through to the response as binary chunks
+  cat.stdout.on('data', function(data) {
+    res.write(data);
+  });
+
+  // End the response on exit (and log errors)
+  cat.on('exit', function(code) {
+    if (code !== 0) {
+      console.error('subprocess exited with code ' + code);
+      exit(1);
+    }
+    res.end();
+  });
+
+});
+
+server.listen(common.PORT, maybeMakeRequest);
+
+console.log('Server running at http://localhost:8080');

--- a/test/simple/test-http-localaddress.js
+++ b/test/simple/test-http-localaddress.js
@@ -1,14 +1,13 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
+if (['linux', 'win32'].indexOf(process.platform) == -1) {
+  console.error('Skipping: platform-specific test.');
+  process.exit(0);
+}
 
 var common = require('../common');
 var http = require('http'),
     assert = require('assert');
-
-if (['linux', 'win32'].indexOf(process.platform) == -1) {
-  console.log('Skipping platform-specific test.');
-  process.exit();
-}
 
 var server = http.createServer(function (req, res) {
   console.log("Connect from: " + req.connection.remoteAddress);

--- a/test/simple/test-https-agent.js
+++ b/test/simple/test-https-agent.js
@@ -1,8 +1,7 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-https-byteswritten.js
+++ b/test/simple/test-https-byteswritten.js
@@ -1,8 +1,7 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-https-client-get-url.js
+++ b/test/simple/test-https-client-get-url.js
@@ -1,8 +1,7 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-https-client-reject.js
+++ b/test/simple/test-https-client-reject.js
@@ -1,8 +1,7 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-https-client-resume.js
+++ b/test/simple/test-https-client-resume.js
@@ -1,12 +1,11 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 // Create an ssl server.  First connection, validate that not resume.
 // Cache session and close connection.  Use session on second connection.
 // ASSERT resumption.
 
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-https-drain.js
+++ b/test/simple/test-https-drain.js
@@ -1,8 +1,7 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-https-eof-for-eom.js
+++ b/test/simple/test-https-eof-for-eom.js
@@ -1,6 +1,5 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 // I hate HTTP. One way of terminating an HTTP response is to not send
 // a content-length header, not send a transfer-encoding: chunked header,
 // and simply terminate the TCP connection. That is identity
@@ -8,8 +7,9 @@
 //
 // This test is to be sure that the https client is handling this case
 // correctly.
+
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-https-foafssl.js
+++ b/test/simple/test-https-foafssl.js
@@ -1,12 +1,15 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
+console.error('Skipping: not supported on any platform.');
+process.exit(0);
 
-return;
-var is_windows = process.platform === 'win32';
+if (process.platform === 'win32') {
+  console.error('Skipping: platform is Windows.');
+  process.exit(0);
+}
 
-if(!is_windows){
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 
@@ -73,4 +76,3 @@ process.on('exit', function() {
       'E8CE66E82D128A71E915809FCF44E8DE774067F1DE5D70B9C03687');
   assert.equal(exponent, '10001');
 });
-}

--- a/test/simple/test-https-invalid-key.js
+++ b/test/simple/test-https-invalid-key.js
@@ -1,8 +1,7 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-https-no-reader.js
+++ b/test/simple/test-https-no-reader.js
@@ -1,8 +1,7 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-https-req-split.js
+++ b/test/simple/test-https-req-split.js
@@ -1,8 +1,7 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-https-simple.js
+++ b/test/simple/test-https-simple.js
@@ -5,7 +5,7 @@ var unsupported = jxcore.utils.OSInfo().isMobile || jxcore.utils.OSInfo().isWind
 if(!unsupported){
 
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-https-socket-options.js
+++ b/test/simple/test-https-socket-options.js
@@ -1,8 +1,7 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-https-strict.js
+++ b/test/simple/test-https-strict.js
@@ -1,8 +1,7 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-https-timeout.js
+++ b/test/simple/test-https-timeout.js
@@ -1,8 +1,7 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-listen-fd-cluster.js
+++ b/test/simple/test-listen-fd-cluster.js
@@ -12,8 +12,8 @@ var cluster = require('cluster');
 console.error('Cluster listen fd test', process.argv.slice(2));
 
 if (process.platform === 'win32') {
-  console.error('This test is disabled on windows.');
-  return;
+  console.error('Skipping: platform is Windows.');
+  process.exit(0);
 }
 
 switch (process.argv[2]) {

--- a/test/simple/test-listen-fd-detached-inherit.js
+++ b/test/simple/test-listen-fd-detached-inherit.js
@@ -9,8 +9,8 @@ var PORT = common.PORT;
 var spawn = require('child_process').spawn;
 
 if (process.platform === 'win32') {
-  console.error('This test is disabled on windows.');
-  return;
+  console.error('Skipping: platform is Windows.');
+  process.exit(0);
 }
 
 switch (process.argv[2]) {

--- a/test/simple/test-listen-fd-detached.js
+++ b/test/simple/test-listen-fd-detached.js
@@ -9,8 +9,8 @@ var PORT = common.PORT;
 var spawn = require('child_process').spawn;
 
 if (process.platform === 'win32') {
-  console.error('This test is disabled on windows.');
-  return;
+  console.error('Skipping: platform is Windows.');
+  process.exit(0);
 }
 
 switch (process.argv[2]) {

--- a/test/simple/test-listen-fd-server.js
+++ b/test/simple/test-listen-fd-server.js
@@ -9,8 +9,8 @@ var PORT = common.PORT;
 var spawn = require('child_process').spawn;
 
 if (process.platform === 'win32') {
-  console.error('This test is disabled on windows.');
-  return;
+  console.error('Skipping: platform is Windows.');
+  process.exit(0);
 }
 
 switch (process.argv[2]) {

--- a/test/simple/test-module-loading-error.js
+++ b/test/simple/test-module-loading-error.js
@@ -1,8 +1,10 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-var is_windows = process.platform === 'win32';
+if (process.platform === 'win32') {
+  console.error('Skipping: platform is Windows.');
+  process.exit(0);
+}
 
-if(!is_windows){
 var common = require('../common');
 var assert = require('assert');
 
@@ -25,5 +27,4 @@ try {
   require('../fixtures/module-loading-error.node');
 } catch (e) {
   assert.notEqual(e.toString().indexOf(dlerror_msg), -1);
-}
 }

--- a/test/simple/test-next-tick-intentional-starvation.js
+++ b/test/simple/test-next-tick-intentional-starvation.js
@@ -1,5 +1,9 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
+if (process.versions.sm) {
+    console.error('Skipping: engine is SpiderMonkey.');
+    process.exit(0);
+}
 
 var common = require('../common');
 var assert = require('assert');
@@ -8,10 +12,6 @@ var assert = require('assert');
 // it verifies that process.nextTick will *always* come before other
 // events, up to the limit of the process.maxTickDepth value.
 
-if(process.versions.sm)
-{
-  return;
-}
 // WARNING: unsafe!
 process.maxTickDepth = Infinity;
 

--- a/test/simple/test-pipe-file-to-http.js
+++ b/test/simple/test-pipe-file-to-http.js
@@ -1,8 +1,10 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-var is_windows = process.platform === 'win32';
+if (process.platform === 'win32') {
+  console.error('Skipping: platform is Windows.');
+  process.exit(0);
+}
 
-if(!is_windows){
 var common = require('../common');
 var assert = require('assert');
 var fs = require('fs');
@@ -94,4 +96,3 @@ process.on('exit', function() {
   assert.equal(1024 * 10240, count);
   assert.ok(clientReqComplete);
 });
-}

--- a/test/simple/test-pipe-head.js
+++ b/test/simple/test-pipe-head.js
@@ -1,10 +1,9 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
-var is_windows = process.platform === 'win32';
-
-if(!is_windows){
-
+if (process.platform === 'win32') {
+  console.error('Skipping: platform is Windows.');
+  process.exit(0);
+}
 
 var common = require('../common');
 var assert = require('assert');
@@ -30,5 +29,3 @@ exec(cmd, function(err, stdout, stderr) {
 process.on('exit', function() {
   assert.ok(finished);
 });
-
-}

--- a/test/simple/test-prepare-stack-trace.js
+++ b/test/simple/test-prepare-stack-trace.js
@@ -6,7 +6,10 @@ var util = require('util');
 
 // test the custom implementation on SM
 // See https://github.com/jxcore/jxcore/issues/728
-if (!process.versions.sm) return;
+if (!process.versions.sm) {
+  console.error('Skipping: test for SpiderMonkey only.');
+  process.exit(0);
+}
 
 function getCallerFile() {
   var oldPrepareStackTrace = Error.prepareStackTrace;

--- a/test/simple/test-process-getgroups.js
+++ b/test/simple/test-process-getgroups.js
@@ -1,13 +1,12 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 var common = require('../common');
 var assert = require('assert');
 var exec = require('child_process').exec;
 
 if (process.platform === 'darwin') {
-  console.log('Skipping. Output of `id -G` is unreliable on Darwin.');
-  return;
+  console.log('Skipping: Output of `id -G` is unreliable on Darwin.');
+  process.exit(0);
 }
 
 if (typeof process.getgroups === 'function') {

--- a/test/simple/test-regress-GH-1531.js
+++ b/test/simple/test-regress-GH-1531.js
@@ -1,8 +1,7 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-regress-GH-746.js
+++ b/test/simple/test-regress-GH-746.js
@@ -1,5 +1,10 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
+// This test currently hangs on Windows
+if (process.platform === 'win32') {
+  console.error('Skipping: platform is Windows.');
+  process.exit(0);
+}
 
 // Just test that destroying stdin doesn't mess up listening on a server.
 // This is a regression test for GH-746.

--- a/test/simple/test-stdout-close-unref.js
+++ b/test/simple/test-stdout-close-unref.js
@@ -1,5 +1,10 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
+// This test currently hangs on Windows.
+if (process.platform === 'win32') {
+  console.error('Skipping: platform is Windows.');
+  process.exit(0);
+}
 
 process.stdin.resume();
 process.stdin._handle.close();

--- a/test/simple/test-tls-client-abort.js
+++ b/test/simple/test-tls-client-abort.js
@@ -1,8 +1,7 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-tls-client-abort2.js
+++ b/test/simple/test-tls-client-abort2.js
@@ -1,8 +1,7 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-tls-client-abort3.js
+++ b/test/simple/test-tls-client-abort3.js
@@ -1,8 +1,7 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-tls-client-destroy-soon.js
+++ b/test/simple/test-tls-client-destroy-soon.js
@@ -1,12 +1,11 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 // Create an ssl server.  First connection, validate that not resume.
 // Cache session and close connection.  Use session on second connection.
 // ASSERT resumption.
 
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-tls-client-reject.js
+++ b/test/simple/test-tls-client-reject.js
@@ -1,8 +1,7 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-tls-client-resume.js
+++ b/test/simple/test-tls-client-resume.js
@@ -1,12 +1,11 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 // Create an ssl server.  First connection, validate that not resume.
 // Cache session and close connection.  Use session on second connection.
 // ASSERT resumption.
 
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-tls-client-verify.js
+++ b/test/simple/test-tls-client-verify.js
@@ -1,8 +1,7 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-tls-close-notify.js
+++ b/test/simple/test-tls-close-notify.js
@@ -1,8 +1,7 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-tls-connect.js
+++ b/test/simple/test-tls-connect.js
@@ -1,8 +1,7 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-tls-invalid-key.js
+++ b/test/simple/test-tls-invalid-key.js
@@ -1,8 +1,7 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-tls-junk-closes-server.js
+++ b/test/simple/test-tls-junk-closes-server.js
@@ -1,8 +1,7 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-tls-npn-server-client.js
+++ b/test/simple/test-tls-npn-server-client.js
@@ -1,8 +1,7 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 if (!process.features.tls_npn) {
-  console.error('Skipping because node compiled without OpenSSL or ' +
+  console.error('Skipping: node compiled without OpenSSL or ' +
                 'with old OpenSSL version.');
   process.exit(0);
 }

--- a/test/simple/test-tls-over-http-tunnel.js
+++ b/test/simple/test-tls-over-http-tunnel.js
@@ -1,8 +1,7 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-tls-passphrase.js
+++ b/test/simple/test-tls-passphrase.js
@@ -1,8 +1,7 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-tls-pause-close.js
+++ b/test/simple/test-tls-pause-close.js
@@ -1,8 +1,7 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-tls-pause.js
+++ b/test/simple/test-tls-pause.js
@@ -1,8 +1,7 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-tls-peer-certificate-multi-keys.js
+++ b/test/simple/test-tls-peer-certificate-multi-keys.js
@@ -1,8 +1,7 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-tls-peer-certificate.js
+++ b/test/simple/test-tls-peer-certificate.js
@@ -1,8 +1,7 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-tls-psk-circuit.js
+++ b/test/simple/test-tls-psk-circuit.js
@@ -1,11 +1,12 @@
 // Copyright Joyent, Inc. and other Node contributors.
 
 if (!process.versions.openssl) {
-  console.error("Skipping because node compiled without OpenSSL.");
+  console.error("Skipping: node compiled without OpenSSL.");
   process.exit(0);
 }
+
 if (parseInt(process.versions.openssl[0]) < 1) {
-  console.error("Skipping because node compiled with old OpenSSL version.");
+  console.error("Skipping: node compiled with old OpenSSL version.");
   process.exit(0);
 }
 

--- a/test/simple/test-tls-psk-client-callback.js
+++ b/test/simple/test-tls-psk-client-callback.js
@@ -1,11 +1,12 @@
 // Copyright Joyent, Inc. and other Node contributors.
 
 if (!process.versions.openssl) {
-  console.error("Skipping because node compiled without OpenSSL.");
+  console.error("Skipping: node compiled without OpenSSL.");
   process.exit(0);
 }
+
 if (parseInt(process.versions.openssl[0]) < 1) {
-  console.error("Skipping because node compiled with old OpenSSL version.");
+  console.error("Skipping: node compiled with old OpenSSL version.");
   process.exit(0);
 }
 

--- a/test/simple/test-tls-psk-client-identity-key.js
+++ b/test/simple/test-tls-psk-client-identity-key.js
@@ -1,11 +1,12 @@
 // Copyright Joyent, Inc. and other Node contributors.
 
 if (!process.versions.openssl) {
-  console.error("Skipping because node compiled without OpenSSL.");
+  console.error("Skipping: node compiled without OpenSSL.");
   process.exit(0);
 }
+
 if (parseInt(process.versions.openssl[0]) < 1) {
-  console.error("Skipping because node compiled with old OpenSSL version.");
+  console.error("Skipping: node compiled with old OpenSSL version.");
   process.exit(0);
 }
 

--- a/test/simple/test-tls-psk-client-identity-nokey.js
+++ b/test/simple/test-tls-psk-client-identity-nokey.js
@@ -1,11 +1,12 @@
 // Copyright Joyent, Inc. and other Node contributors.
 
 if (!process.versions.openssl) {
-  console.error("Skipping because node compiled without OpenSSL.");
+  console.error("Skipping: node compiled without OpenSSL.");
   process.exit(0);
 }
+
 if (parseInt(process.versions.openssl[0]) < 1) {
-  console.error("Skipping because node compiled with old OpenSSL version.");
+  console.error("Skipping: node compiled with old OpenSSL version.");
   process.exit(0);
 }
 

--- a/test/simple/test-tls-psk-client-noidentity-key.js
+++ b/test/simple/test-tls-psk-client-noidentity-key.js
@@ -1,11 +1,12 @@
 // Copyright Joyent, Inc. and other Node contributors.
 
 if (!process.versions.openssl) {
-  console.error("Skipping because node compiled without OpenSSL.");
+  console.error("Skipping: node compiled without OpenSSL.");
   process.exit(0);
 }
+
 if (parseInt(process.versions.openssl[0]) < 1) {
-  console.error("Skipping because node compiled with old OpenSSL version.");
+  console.error("Skipping: node compiled with old OpenSSL version.");
   process.exit(0);
 }
 

--- a/test/simple/test-tls-psk-client.js
+++ b/test/simple/test-tls-psk-client.js
@@ -1,15 +1,17 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
 if (process.env.CITEST) {
-    console.error('Skipping test due to CITEST environment variable. (old openssl.exe)');
+    console.error('Skipping: due to CITEST environment variable. (old openssl.exe)');
     process.exit(0);
 }
+
 if (!process.versions.openssl) {
-    console.error("Skipping because node compiled without OpenSSL.");
+    console.error("Skipping: node compiled without OpenSSL.");
     process.exit(0);
 }
+
 if (parseInt(process.versions.openssl[0]) < 1) {
-    console.error("Skipping because node compiled with old OpenSSL version.");
+    console.error("Skipping: node compiled with old OpenSSL version.");
     process.exit(0);
 }
 
@@ -39,8 +41,8 @@ function checkOpenSSL() {
   });
 }
 
-if (! checkOpenSSL()){
-  console.error("Skipping because OpenSSL version < 1.0.0.");
+if (!checkOpenSSL()){
+  console.error("Skipping: OpenSSL version < 1.0.0.");
   process.exit(0)
 }
 

--- a/test/simple/test-tls-psk-server.js
+++ b/test/simple/test-tls-psk-server.js
@@ -1,12 +1,12 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 if (!process.versions.openssl) {
-  console.error("Skipping because node compiled without OpenSSL.");
+  console.error("Skipping: node compiled without OpenSSL.");
   process.exit(0);
 }
+
 if (parseInt(process.versions.openssl[0]) < 1) {
-  console.error("Skipping because node compiled with old OpenSSL version.");
+  console.error("Skipping: node compiled with old OpenSSL version.");
   process.exit(0);
 }
 
@@ -38,8 +38,8 @@ function checkOpenSSL() {
   });
 }
 
-if (! checkOpenSSL()){
-  console.error("Skipping because OpenSSL version < 1.0.0.");
+if (!checkOpenSSL()){
+  console.error("Skipping: OpenSSL version < 1.0.0.");
   process.exit(0)
 }
 

--- a/test/simple/test-tls-remote.js
+++ b/test/simple/test-tls-remote.js
@@ -1,8 +1,7 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-tls-securepair-client.js
+++ b/test/simple/test-tls-securepair-client.js
@@ -1,10 +1,13 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
 // this test file is not compatible to Windows
-if (process.platform === 'win32') return;
+if (process.platform === 'win32') {
+  console.error('Skipping: platform is Windows.');
+  process.exit(0);
+}
 
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-tls-securepair-server.js
+++ b/test/simple/test-tls-securepair-server.js
@@ -1,10 +1,13 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
 // this test file is not compatible to Windows
-if (process.platform === 'win32') return;
+if (process.platform === 'win32') {
+  console.error('Skipping: platform is Windows.');
+  process.exit(0);
+}
 
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-tls-server-missing-options.js
+++ b/test/simple/test-tls-server-missing-options.js
@@ -1,8 +1,7 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-tls-server-verify.js
+++ b/test/simple/test-tls-server-verify.js
@@ -1,12 +1,10 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
-
-  process.exit(0);
-
+console.error('Skipping: not supported on any platform.');
+process.exit(0);
 
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-tls-session-cache.js
+++ b/test/simple/test-tls-session-cache.js
@@ -1,13 +1,13 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
+
 require('child_process').exec('openssl version', function(err) {
   if (err !== null) {
-    console.error('Skipping because openssl command is not available.');
+    console.error('Skipping: openssl command is not available.');
     process.exit(0);
   }
   doTest();

--- a/test/simple/test-tls-sni-server-client.js
+++ b/test/simple/test-tls-sni-server-client.js
@@ -1,11 +1,7 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
-
-
-
 if (!process.features.tls_sni) {
-  console.error('Skipping because node compiled without OpenSSL or ' +
+  console.error('Skipping: node compiled without OpenSSL or ' +
                 'with old OpenSSL version.');
   process.exit(0);
 }

--- a/test/simple/test-tls-ssl2-methods.js
+++ b/test/simple/test-tls-ssl2-methods.js
@@ -6,8 +6,8 @@ var assert = require('assert');
 try {
   var crypto = require('crypto');
 } catch (e) {
-    console.log('1..0 # Skipped: missing crypto');
-    return;
+    console.error('Skipping: missing crypto.');
+    process.exit(0);
 }
 
 var methods = ['SSLv2_method', 'SSLv2_client_method', 'SSLv2_server_method'];

--- a/test/simple/test-tls-zero-clear-in.js
+++ b/test/simple/test-tls-zero-clear-in.js
@@ -1,8 +1,7 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+  console.error('Skipping: node compiled without OpenSSL.');
   process.exit(0);
 }
 

--- a/test/simple/test-tty-wrap.js
+++ b/test/simple/test-tty-wrap.js
@@ -8,7 +8,7 @@ var TTY = process.binding('tty_wrap').TTY;
 var isTTY = process.binding('tty_wrap').isTTY;
 
 if (isTTY(1) == false) {
-  console.error('fd 1 is not a tty. skipping test.');
+  console.error('Skipping: fd 1 is not a tty.');
   process.exit(0);
 }
 

--- a/test/simple/test-typed-arrays.js
+++ b/test/simple/test-typed-arrays.js
@@ -1,16 +1,22 @@
 // Copyright & License details are available under JXCORE_LICENSE file
 
-
 /*
  * Test to verify we are using Typed Arrays
  * (http://www.khronos.org/registry/typedarray/specs/latest/) correctly Test to
  * verify Buffer can used in Typed Arrays
  */
  
-// SpiderMonkey, V8 3.28+ implementation has native TypedArray support
+// SpiderMonkey, V8 > 3.14 implementation has native TypedArray support
 var ver = process.versions;
-if (ver.sm || ver.ch) return; 
-if (parseFloat(ver.v8) > 3.15) return;
+if (ver.sm || ver.ch) {
+  console.error('Skipping: SpiderMonkey and Chakra have native TypedArray support.');
+  process.exit(0);
+} 
+
+if (parseFloat(ver.v8) > 3.14) {
+  console.error('Skipping: V8 > 3.14 has native TypedArray support.');
+  process.exit(0);
+}
 
 var common = require('../common');
 var assert = require('assert');

--- a/test/test.js
+++ b/test/test.js
@@ -31,6 +31,7 @@ var allFiles = [], cwd = process.cwd() + path.sep, dir = cwd + "test"
   percent : 0,
   passed : 0,
   failed : 0,
+  skipped : 0,
   time_started : null,
   minutes_ellapsed : null,
   seconds_ellapsed : null
@@ -91,10 +92,11 @@ var writeStats = function(obj) {
   var percent = jxcore.utils.console.setColor("%% %s", "blue");
   var success = jxcore.utils.console.setColor("+ %s", "green");
   var failures = jxcore.utils.console.setColor("- %s", "red");
-  var s = util.format("[" + [ time, percent, success, failures ].join("|")
+  var skipped = jxcore.utils.console.setColor("- %s", "yellow");
+  var s = util.format("[" + [ time, percent, success, failures, skipped ].join("|")
       + "] " + fname.replace(cwd, ""), pad(stats.minutes_ellapsed, 2, '0'),
       pad(stats.seconds_ellapsed, 2, '0'), pad(stats.percent, 3, ' '), pad(
-          stats.passed, 3, ' '), pad(stats.failed, 3, ' '));
+          stats.passed, 3, ' '), pad(stats.failed, 3, ' '), pad(stats.skipped, 3, ' '));
 
   console.log(cursorUp + clearLine + s);
 };
@@ -110,9 +112,12 @@ var addStat = function(ret) {
     jxcore.utils.console.log(ret.out.toString().trim());
     jxcore.utils.console.log("Command:", ret.cmd, "yellow");
     jxcore.utils.console.log("\n");
+  } else if (ret.err.indexOf("Skipping:",0) > -1) {
+      stats.skipped++;
   } else {
-    stats.passed++;
+      stats.passed++;
   }
+}
 
   var seconds_delta = (Date.now() - stats.time_started) / 1000;
   stats.minutes_ellapsed = Math.floor(seconds_delta / 60);


### PR DESCRIPTION
Until now, tests results only showed 'passed' and 'failed' tests.
There wasn't a standard method to log 'skipped' tests.
I've changed the tests in test/simple to use the same way to report a skipped test:
```
   console.error('Skipping: .... .'); // replace ... with the reason for skipping the test
   process.exit(0);
```
I've changed test/test.js and tools/test.py to report the skipped tests in all the different process modes (verbose, dots, color, mono, tap).
